### PR TITLE
release: sapphire-workspace 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-retrieve"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -5536,7 +5536,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-sync"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "git2",
  "serde",
@@ -5545,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-workspace"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "dirs 5.0.1",
  "indexmap 2.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 description = "Workspace management library for indexing, search, and sync of file-based documents"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-workspace"

--- a/sapphire-workspace/Cargo.toml
+++ b/sapphire-workspace/Cargo.toml
@@ -16,8 +16,8 @@ fastembed-embed = ["sapphire-retrieve/fastembed-embed"]
 git-sync        = ["sapphire-sync/git"]
 
 [dependencies]
-sapphire-retrieve = { version = "0.5.0", path = "../sapphire-retrieve", default-features = false }
-sapphire-sync     = { version = "0.5.0", path = "../sapphire-sync", default-features = false }
+sapphire-retrieve = { version = "0.5.1", path = "../sapphire-retrieve", default-features = false }
+sapphire-sync     = { version = "0.5.1", path = "../sapphire-sync", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/sapphire-workspace/examples/cli/Cargo.toml
+++ b/sapphire-workspace/examples/cli/Cargo.toml
@@ -19,7 +19,7 @@ fastembed-embed = ["sapphire-workspace/fastembed-embed"]
 git-sync        = ["sapphire-workspace/git-sync"]
 
 [dependencies]
-sapphire-workspace = { version = "0.5.0", path = "../..", default-features = false }
+sapphire-workspace = { version = "0.5.1", path = "../..", default-features = false }
 clap.workspace = true
 anyhow.workspace = true
 serde.workspace = true

--- a/sapphire-workspace/src/workspace_state.rs
+++ b/sapphire-workspace/src/workspace_state.rs
@@ -332,7 +332,7 @@ impl WorkspaceState {
             }
             #[cfg(not(feature = "lancedb-store"))]
             VectorDb::LanceDb => {
-                return Err(Error::LanceDbNotEnabled);
+                return Err(crate::error::Error::LanceDbNotEnabled);
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary

- Bump all three crates to 0.5.1.
- Fix a compile error in \`workspace_state.rs\` when the \`lancedb-store\` feature is disabled: the \`VectorDb::LanceDb\` arm referenced an unqualified \`Error\` type. Qualified it as \`crate::error::Error\` to match the neighboring \`SqliteStoreNotEnabled\` arm.

Fixes fluo10/sapphire-journal#148

## Test plan

- [x] \`cargo check --workspace\` (default features)
- [x] \`cargo check -p sapphire-workspace --no-default-features\`
- [x] \`cargo check -p sapphire-workspace --no-default-features --features git-sync\`
- [x] \`cargo check -p sapphire-workspace --no-default-features --features sqlite-store\`