### PR TITLE
feat: add retrieve_files with hybrid search

### DIFF
--- a/crates/sapphire-retrieve/src/config.rs
+++ b/crates/sapphire-retrieve/src/config.rs
@@ -15,6 +15,40 @@ pub struct RetrieveConfig {
     /// if `db` is set to a non-`none` value.
     #[serde(default)]
     pub embedding: Option<EmbeddingConfig>,
+    /// Hybrid search tuning (FTS + semantic merged via Reciprocal Rank Fusion).
+    #[serde(default)]
+    pub hybrid: HybridConfig,
+}
+
+/// Settings for hybrid (FTS + semantic) search merging via Reciprocal Rank
+/// Fusion (RRF).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HybridConfig {
+    /// Weight for FTS results in RRF fusion (0.0–1.0, default 0.5).
+    /// The semantic weight is `1.0 - fts_weight`.
+    #[serde(default = "default_fts_weight")]
+    pub fts_weight: f64,
+    /// Constant *k* in the RRF formula: `score = 1 / (k + rank)`.
+    /// Default 60.
+    #[serde(default = "default_rrf_k")]
+    pub rrf_k: u32,
+}
+
+fn default_fts_weight() -> f64 {
+    0.5
+}
+
+fn default_rrf_k() -> u32 {
+    60
+}
+
+impl Default for HybridConfig {
+    fn default() -> Self {
+        Self {
+            fts_weight: default_fts_weight(),
+            rrf_k: default_rrf_k(),
+        }
+    }
 }
 
 /// Vector database backend for approximate (semantic) text search.

--- a/crates/sapphire-retrieve/src/lib.rs
+++ b/crates/sapphire-retrieve/src/lib.rs
@@ -11,7 +11,7 @@ pub mod sqlite_store;
 pub mod vector_store;
 
 pub use chunker::{Chunker, JsonChunker, MarkdownChunker, TextChunk};
-pub use config::{EmbeddingConfig, RetrieveConfig, VectorDb};
+pub use config::{EmbeddingConfig, HybridConfig, RetrieveConfig, VectorDb};
 pub use db::{Document, RetrieveDb, SearchResult};
 pub use embed::{build_embedder, EmbedderConfig, Embedder};
 pub use error::{Error, Result};

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::{Error, Result};
 
 // Re-export config types from their home crates.
-pub use sapphire_retrieve::config::{EmbeddingConfig, RetrieveConfig, VectorDb};
+pub use sapphire_retrieve::config::{EmbeddingConfig, HybridConfig, RetrieveConfig, VectorDb};
 pub use sapphire_sync::config::{SyncBackendKind, SyncConfig};
 
 // ── WorkspaceConfig (per-workspace, stored in {marker}/config.toml) ──────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,12 @@ pub mod workspace_state;
 mod error;
 pub use error::{Error, Result};
 
-pub use config::{EmbeddingConfig, RetrieveConfig, SyncBackendKind, SyncConfig, UserConfig, VectorDb, WorkspaceConfig};
+pub use config::{EmbeddingConfig, HybridConfig, RetrieveConfig, SyncBackendKind, SyncConfig, UserConfig, VectorDb, WorkspaceConfig};
 pub use context::AppContext;
 pub use workspace::{DEFAULT_WORKSPACE_MARKER, path_uuid};
 pub use indexer::path_to_doc_id;
 pub use workspace::Workspace;
-pub use workspace_state::{DbInfo, WorkspaceState};
+pub use workspace_state::{DbInfo, RetrieveParams, SearchMode, WorkspaceState};
 
 // Re-export sapphire-retrieve public API so callers can use a single dependency.
 pub use sapphire_retrieve::{

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -1,18 +1,45 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use sapphire_retrieve::{Document, Embedder, RetrieveDb};
+use sapphire_retrieve::{Document, Embedder, RetrieveDb, SearchResult};
 #[cfg(feature = "sqlite-store")]
 use sapphire_retrieve::db::SCHEMA_VERSION;
 use tokio::sync::OnceCell;
 
 use crate::{
-    config::{UserConfig, VectorDb, WorkspaceConfig},
+    config::{HybridConfig, UserConfig, VectorDb, WorkspaceConfig},
     error::Result,
     indexer::{path_to_doc_id, sync_workspace},
     workspace::Workspace,
 };
 
 use sapphire_retrieve::build_embedder;
+
+/// Controls which retrieval strategy [`WorkspaceState::retrieve_files`] uses.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SearchMode {
+    /// Full-text search only (BM25 / trigram).
+    Fts,
+    /// Semantic (vector) search only.  Falls back to FTS if no embedder is
+    /// configured.
+    Semantic,
+    /// Combine FTS and semantic results via Reciprocal Rank Fusion (default).
+    #[default]
+    Hybrid,
+}
+
+/// Parameters for [`WorkspaceState::retrieve_files`].
+pub struct RetrieveParams<'a> {
+    /// The search query string.
+    pub query: &'a str,
+    /// Maximum number of results to return.
+    pub limit: usize,
+    /// Retrieval strategy (default: [`SearchMode::Hybrid`]).
+    pub mode: SearchMode,
+    /// Optional folder prefix filter.  Only results whose path starts with
+    /// this prefix are returned.  Should be an absolute path.
+    pub folder: Option<&'a Path>,
+}
 
 /// An open workspace paired with its lazily-initialised search infrastructure.
 pub struct WorkspaceState {
@@ -454,5 +481,138 @@ impl WorkspaceState {
             vector_count: vec_info.vector_count,
             pending_count: vec_info.pending_count,
         })
+    }
+
+    // ── retrieve (unified search) ────────────────────────────────────────────
+
+    /// Retrieve files matching `query` using the specified search mode.
+    ///
+    /// - **Fts**: full-text search only.
+    /// - **Semantic**: vector search only (falls back to FTS when no embedder
+    ///   is loaded).
+    /// - **Hybrid** (default): runs both FTS and semantic search, then merges
+    ///   results via Reciprocal Rank Fusion (RRF).
+    ///
+    /// When `params.folder` is set, results are post-filtered to paths that
+    /// start with that prefix.
+    pub fn retrieve_files(
+        &self,
+        params: &RetrieveParams<'_>,
+        hybrid_config: &HybridConfig,
+    ) -> Result<Vec<SearchResult>> {
+        // Over-fetch to compensate for post-filter losses.
+        let fetch_limit = if params.folder.is_some() {
+            params.limit * 3
+        } else {
+            params.limit
+        };
+
+        // Fall back to FTS when the embedder is not available.
+        let effective_mode = match params.mode {
+            SearchMode::Semantic | SearchMode::Hybrid if self.embedder().is_none() => {
+                SearchMode::Fts
+            }
+            other => other,
+        };
+
+        let results = match effective_mode {
+            SearchMode::Fts => self.search_fts_internal(params.query, fetch_limit)?,
+            SearchMode::Semantic => self.search_semantic_internal(params.query, fetch_limit)?,
+            SearchMode::Hybrid => {
+                self.search_hybrid_internal(params.query, fetch_limit, hybrid_config)?
+            }
+        };
+
+        let results = Self::filter_by_folder(results, params.folder);
+        Ok(results.into_iter().take(params.limit).collect())
+    }
+
+    fn search_fts_internal(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
+        Ok(self.retrieve_db.search_fts(query, limit)?)
+    }
+
+    fn search_semantic_internal(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>> {
+        let embedder = self.embedder().expect("caller verified embedder exists");
+        let query_vecs = embedder.embed_texts(&[query])?;
+        let query_vec = query_vecs
+            .into_iter()
+            .next()
+            .ok_or_else(|| sapphire_retrieve::Error::Embed("embedder returned empty result".into()))?;
+        let raw = self.retrieve_db.search_similar(&query_vec, limit * 3)?;
+        Ok(RetrieveDb::dedup_chunk_results(raw, limit))
+    }
+
+    fn search_hybrid_internal(
+        &self,
+        query: &str,
+        limit: usize,
+        config: &HybridConfig,
+    ) -> Result<Vec<SearchResult>> {
+        let fts_results = self.search_fts_internal(query, limit)?;
+        let sem_results = self.search_semantic_internal(query, limit)?;
+        Ok(Self::merge_rrf(fts_results, sem_results, limit, config))
+    }
+
+    /// Merge two ranked result lists via Reciprocal Rank Fusion.
+    ///
+    /// `score(d) = w_fts / (k + rank_fts) + w_sem / (k + rank_sem)`
+    ///
+    /// Documents appearing in only one list receive a contribution from that
+    /// list alone.  The returned list is sorted by descending RRF score.
+    fn merge_rrf(
+        fts: Vec<SearchResult>,
+        semantic: Vec<SearchResult>,
+        limit: usize,
+        config: &HybridConfig,
+    ) -> Vec<SearchResult> {
+        let k = config.rrf_k as f64;
+        let w_fts = config.fts_weight;
+        let w_sem = 1.0 - w_fts;
+
+        let mut scores: HashMap<String, (SearchResult, f64)> = HashMap::new();
+
+        for (rank, result) in fts.into_iter().enumerate() {
+            let rrf = w_fts / (k + (rank + 1) as f64);
+            scores
+                .entry(result.path.clone())
+                .and_modify(|(_, s)| *s += rrf)
+                .or_insert((result, rrf));
+        }
+
+        for (rank, result) in semantic.into_iter().enumerate() {
+            let rrf = w_sem / (k + (rank + 1) as f64);
+            scores
+                .entry(result.path.clone())
+                .and_modify(|(_, s)| *s += rrf)
+                .or_insert((result, rrf));
+        }
+
+        let mut merged: Vec<_> = scores.into_values().collect();
+        merged.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        merged.truncate(limit);
+
+        merged
+            .into_iter()
+            .map(|(mut result, rrf_score)| {
+                result.score = rrf_score;
+                result
+            })
+            .collect()
+    }
+
+    fn filter_by_folder(
+        results: Vec<SearchResult>,
+        folder: Option<&Path>,
+    ) -> Vec<SearchResult> {
+        let Some(prefix) = folder else { return results };
+        let prefix_str = prefix.to_string_lossy();
+        results
+            .into_iter()
+            .filter(|r| r.path.starts_with(prefix_str.as_ref()))
+            .collect()
     }
 }


### PR DESCRIPTION
## Summary
- Add `WorkspaceState::retrieve_files` supporting full-text search (FTS), semantic search, and hybrid search (default)
- Hybrid mode merges FTS and semantic results via Reciprocal Rank Fusion (RRF) with configurable `fts_weight` and `rrf_k`
- Support folder-based path filtering to scope search results to a specific directory
- Add `HybridConfig` to `RetrieveConfig` (`[retrieve.hybrid]` section in config)

## New API
```rust
pub enum SearchMode { Fts, Semantic, #[default] Hybrid }

pub struct RetrieveParams<'a> {
    pub query: &'a str,
    pub limit: usize,
    pub mode: SearchMode,
    pub folder: Option<&'a Path>,
}

state.retrieve_files(&params, &hybrid_config) -> Result<Vec<SearchResult>>
```

## Design
- **RRF**: Rank-based fusion avoids the need to normalize incompatible BM25 and L2 distance scores
- **Graceful fallback**: When embedder is not configured, Semantic/Hybrid modes automatically degrade to FTS-only
- **Folder filtering**: Post-query filtering with 3x over-fetch to compensate for filtered-out results

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (all existing tests)
- [ ] Manual test: create workspace, sync files, call `retrieve_files` with each `SearchMode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)