### PR TITLE
release: sapphire-workspace 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to `sapphire-workspace` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-11
+
+### Added
+
+- `WorkspaceState::retrieve_files` — unified search method supporting full-text, semantic, and hybrid (FTS + semantic via Reciprocal Rank Fusion) modes with configurable weights; accepts an optional folder path filter for scoping results.
+- `WorkspaceState::sync_workspace_incremental` — mtime-based incremental indexer that only re-indexes files changed since the last sync, making periodic background refreshes much cheaper than a full rescan.
+- `WorkspaceState::periodic_sync` — orchestrates a full sync cycle: git sync (if configured) followed by an incremental cache refresh.
+- `SyncConfig::device_id: Option<Uuid>` and `SyncConfig::ensure_device_id()` — per-device UUID embedded in git commit messages for tracing sync origin across devices.
+- CLI: layered config loading via the `config` crate — workspace-level `{marker}/config.toml` (shared across devices) merged with a per-user override file (`$XDG_CONFIG_HOME/sapphire-workspace/config.toml`).
+- CLI: per-device UUID managed in the user-level config; git commits carry the message `auto: sync [<uuid>]`.
+
+### Changed
+
+- `sync_interval_minutes` moved from `SyncConfig` (`sapphire-sync`) to `WorkspaceConfig` (`sapphire-workspace`); periodic sync is now orchestrated by `WorkspaceState` to cover both git sync and cache refresh.
+
+### Removed
+
+- `sapphire_workspace::util::merge_toml_values` — use the `config` crate directly for layered config merging.
+
+## [0.5.1] - 2026-04-08
+
+Internal repository restructure; no public API changes.
+
 ## [0.5.0] - 2026-04-08
 
 ### Added
@@ -73,6 +96,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `fastembed-embed`, `lancedb-store`, `sqlite-store`, `git-sync` feature flags.
 - Re-exports of `sapphire-retrieve` and `sapphire-sync` public APIs.
 
+[0.6.0]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.5.1...workspace-v0.6.0
+[0.5.1]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.5.0...workspace-v0.5.1
 [0.5.0]: https://github.com/fluo10/sapphire-journal/compare/workspace-v0.4.0...workspace-v0.5.0
 [0.4.0]: https://github.com/fluo10/sapphire-journal/compare/workspace-v0.3.0...workspace-v0.4.0
 [0.3.0]: https://github.com/fluo10/sapphire-journal/compare/workspace-v0.2.0...workspace-v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 description = "Workspace management library for indexing, search, and sync of file-based documents"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-workspace"
@@ -50,8 +50,8 @@ fastembed-embed = ["sapphire-retrieve/fastembed-embed"]
 git-sync        = ["sapphire-sync/git"]
 
 [dependencies]
-sapphire-retrieve = { version = "0.5.1", path = "crates/sapphire-retrieve", default-features = false }
-sapphire-sync     = { version = "0.5.1", path = "crates/sapphire-sync", default-features = false }
+sapphire-retrieve = { version = "0.6.0", path = "crates/sapphire-retrieve", default-features = false }
+sapphire-sync     = { version = "0.6.0", path = "crates/sapphire-sync", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Workspace management library for indexing, search, and sync of Markdown document
 
 ```toml
 [dependencies]
-sapphire-workspace = "0.5"
+sapphire-workspace = "0.6"
 ```
 
 ### Initialise a workspace

--- a/crates/sapphire-workspace-cli/Cargo.toml
+++ b/crates/sapphire-workspace-cli/Cargo.toml
@@ -19,7 +19,7 @@ fastembed-embed = ["sapphire-workspace/fastembed-embed"]
 git-sync        = ["sapphire-workspace/git-sync"]
 
 [dependencies]
-sapphire-workspace = { version = "0.5.1", path = "../..", default-features = false }
+sapphire-workspace = { version = "0.6.0", path = "../..", default-features = false }
 clap.workspace = true
 anyhow.workspace = true
 serde.workspace = true


### PR DESCRIPTION
## Summary

- Bump workspace version `0.5.1` → `0.6.0` across all `Cargo.toml` files
- Add CHANGELOG entry for v0.6.0
- Update README quick-start dependency to `"0.6"`

## Changes in this release

- `WorkspaceState::retrieve_files` — hybrid search (FTS + semantic via RRF) with folder filter
- `WorkspaceState::sync_workspace_incremental` — mtime-based incremental indexer
- `WorkspaceState::periodic_sync` — full sync cycle (git + cache refresh)
- `SyncConfig::device_id` / `ensure_device_id()` — per-device UUID in git commit messages
- CLI: layered config loading via `config` crate (workspace-level + per-user override)
- `sync_interval_minutes` moved from `SyncConfig` to `WorkspaceConfig`
- Removed `sapphire_workspace::util::merge_toml_values`

## Test plan

- [x] `cargo publish --dry-run` passed for all publishable crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)