### PR TITLE
fix: resolve cargo clippy warnings (-D warnings)

### DIFF
--- a/crates/sapphire-retrieve/src/chunker.rs
+++ b/crates/sapphire-retrieve/src/chunker.rs
@@ -288,8 +288,7 @@ fn chunks_from_json_value(raw: &str, value: &serde_json::Value) -> Vec<TextChunk
                         .iter()
                         .enumerate()
                         .map(|(i, v)| {
-                            let (line, column) =
-                                nested_positions.get(i).copied().unwrap_or((i, 0));
+                            let (line, column) = nested_positions.get(i).copied().unwrap_or((i, 0));
                             TextChunk {
                                 line,
                                 column,

--- a/crates/sapphire-retrieve/src/chunker.rs
+++ b/crates/sapphire-retrieve/src/chunker.rs
@@ -278,25 +278,25 @@ fn chunks_from_json_value(raw: &str, value: &serde_json::Value) -> Vec<TextChunk
             // Look for a nested messages/chat array.
             const ARRAY_KEYS: &[&str] = &["messages", "chat", "history", "log"];
             for key in ARRAY_KEYS {
-                if let Some(serde_json::Value::Array(arr)) = map.get(*key) {
-                    if !arr.is_empty() {
-                        // Find the position of this key's array in the raw text,
-                        // then scan for element positions within it.
-                        let nested_positions = find_nested_array_positions(raw, key);
-                        return arr
-                            .iter()
-                            .enumerate()
-                            .map(|(i, v)| {
-                                let (line, column) =
-                                    nested_positions.get(i).copied().unwrap_or((i, 0));
-                                TextChunk {
-                                    line,
-                                    column,
-                                    text: extract_message_text(v),
-                                }
-                            })
-                            .collect();
-                    }
+                if let Some(serde_json::Value::Array(arr)) = map.get(*key)
+                    && !arr.is_empty()
+                {
+                    // Find the position of this key's array in the raw text,
+                    // then scan for element positions within it.
+                    let nested_positions = find_nested_array_positions(raw, key);
+                    return arr
+                        .iter()
+                        .enumerate()
+                        .map(|(i, v)| {
+                            let (line, column) =
+                                nested_positions.get(i).copied().unwrap_or((i, 0));
+                            TextChunk {
+                                line,
+                                column,
+                                text: extract_message_text(v),
+                            }
+                        })
+                        .collect();
                 }
             }
             // Single object — one chunk at the start of the file.

--- a/crates/sapphire-retrieve/src/db.rs
+++ b/crates/sapphire-retrieve/src/db.rs
@@ -67,6 +67,7 @@ struct InMemoryState {
 }
 
 impl InMemoryStore {
+    #[allow(dead_code)]
     fn new() -> Self {
         Self {
             state: Mutex::new(InMemoryState::default()),
@@ -179,6 +180,7 @@ enum BackendState {
     ///
     /// Used when neither `sqlite-store` nor `lancedb-store` is compiled in,
     /// and as the initial state before [`RetrieveDb::init_lancedb`] is called.
+    #[allow(dead_code)]
     InMemory(Arc<InMemoryStore>),
     /// SQLite backend (FTS only or FTS + sqlite-vec).
     #[cfg(feature = "sqlite-store")]
@@ -242,10 +244,10 @@ impl RetrieveDb {
         #[cfg(feature = "sqlite-store")]
         {
             let store = SqliteStore::new_fts_only(db_path.to_owned());
-            return Ok(Self {
+            Ok(Self {
                 db_path: db_path.to_owned(),
                 backend: Mutex::new(BackendState::Sqlite(Arc::new(store))),
-            });
+            })
         }
 
         #[cfg(not(feature = "sqlite-store"))]

--- a/crates/sapphire-retrieve/src/embed.rs
+++ b/crates/sapphire-retrieve/src/embed.rs
@@ -236,7 +236,7 @@ fn embed_ollama(config: &EmbedderConfig, texts: &[&str]) -> Result<Vec<Vec<f32>>
             Error::Embed("unexpected Ollama response: missing `embeddings` array".into())
         })?
         .iter()
-        .map(|arr| parse_float_array(arr))
+        .map(parse_float_array)
         .collect()
 }
 

--- a/crates/sapphire-retrieve/src/sqlite_store.rs
+++ b/crates/sapphire-retrieve/src/sqlite_store.rs
@@ -86,6 +86,7 @@ static SQLITE_VEC_INIT: Once = Once::new();
 
 fn init_sqlite_vec_extension() {
     SQLITE_VEC_INIT.call_once(|| unsafe {
+        #[allow(clippy::missing_transmute_annotations)]
         rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute(
             sqlite_vec::sqlite3_vec_init as *const (),
         )));

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -217,10 +217,10 @@ pub fn sync_workspace_incremental(
         // Check mtime — skip if unchanged.
         let path_str = path.to_string_lossy();
         let disk_mtime = file_mtime_secs(path);
-        if let Some(&cached_mtime) = known_mtimes.get(path_str.as_ref()) {
-            if cached_mtime == disk_mtime {
-                continue;
-            }
+        if let Some(&cached_mtime) = known_mtimes.get(path_str.as_ref())
+            && cached_mtime == disk_mtime
+        {
+            continue;
         }
 
         let raw = match std::fs::read_to_string(path) {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -203,9 +203,8 @@ impl Workspace {
         #[cfg(feature = "sqlite-store")]
         {
             use sapphire_retrieve::db::SCHEMA_VERSION;
-            return self
-                .cache_dir()
-                .join(format!("retrieve_v{SCHEMA_VERSION}.db"));
+            self.cache_dir()
+                .join(format!("retrieve_v{SCHEMA_VERSION}.db"))
         }
         #[cfg(not(feature = "sqlite-store"))]
         self.cache_dir().join("retrieve.db")


### PR DESCRIPTION
## Summary

- Add `#[allow(dead_code)]` to `InMemoryStore::new` and `BackendState::InMemory`, which are only constructed when the `sqlite-store` feature is disabled
- Remove redundant `return` statements in `#[cfg]`-gated blocks (`db.rs`, `workspace.rs`)
- Collapse nested `if let … { if … }` into `if let … && …` chains (`chunker.rs`, `indexer.rs`)
- Replace redundant closure `|arr| parse_float_array(arr)` with `parse_float_array` (`embed.rs`)
- Add `#[allow(clippy::missing_transmute_annotations)]` to the `sqlite3_auto_extension` transmute in `sqlite_store.rs`

## Test plan

- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes with no errors
- [ ] `cargo test --all-features --locked` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)