### PR TITLE
refactor: replace RetrieveDb with Arc<dyn RetrieveStore> in WorkspaceState

### DIFF
--- a/crates/sapphire-retrieve/src/db.rs
+++ b/crates/sapphire-retrieve/src/db.rs
@@ -67,7 +67,6 @@ struct InMemoryState {
 }
 
 impl InMemoryStore {
-    #[allow(dead_code)]
     fn new() -> Self {
         Self {
             state: Mutex::new(InMemoryState::default()),
@@ -355,34 +354,13 @@ impl RetrieveDb {
     /// When multiple chunks from the same document match, only the best-scoring
     /// (lowest L2 distance) chunk is kept.  Returns up to `limit` results
     /// ordered by ascending score.
+    ///
+    /// # Deprecation
+    ///
+    /// Prefer the free function [`dedup_chunk_results`] instead.
+    #[deprecated(since = "0.7.0", note = "use the free function `dedup_chunk_results` instead")]
     pub fn dedup_chunk_results(results: Vec<ChunkSearchResult>, limit: usize) -> Vec<SearchResult> {
-        let mut best: HashMap<i64, ChunkSearchResult> = HashMap::new();
-        for r in results {
-            best.entry(r.doc_id)
-                .and_modify(|e| {
-                    if r.score < e.score {
-                        *e = r.clone();
-                    }
-                })
-                .or_insert(r);
-        }
-
-        let mut deduped: Vec<_> = best.into_values().collect();
-        deduped.sort_by(|a, b| {
-            a.score
-                .partial_cmp(&b.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-        deduped.truncate(limit);
-        deduped
-            .into_iter()
-            .map(|r| SearchResult {
-                id: r.doc_id,
-                title: r.doc_title,
-                path: r.doc_path,
-                score: r.score,
-            })
-            .collect()
+        dedup_chunk_results(results, limit)
     }
 
     // ── embedding ─────────────────────────────────────────────────────────────
@@ -437,4 +415,72 @@ impl RetrieveDb {
     pub fn file_count(&self) -> Result<u64> {
         self.store().file_count()
     }
+}
+
+// ── free functions ────────────────────────────────────────────────────────────
+
+/// Deduplicate chunk search results to one [`SearchResult`] per document.
+///
+/// When multiple chunks from the same document match, only the best-scoring
+/// (lowest L2 distance) chunk is kept.  Returns up to `limit` results
+/// ordered by ascending score.
+pub fn dedup_chunk_results(results: Vec<ChunkSearchResult>, limit: usize) -> Vec<SearchResult> {
+    let mut best: HashMap<i64, ChunkSearchResult> = HashMap::new();
+    for r in results {
+        best.entry(r.doc_id)
+            .and_modify(|e| {
+                if r.score < e.score {
+                    *e = r.clone();
+                }
+            })
+            .or_insert(r);
+    }
+
+    let mut deduped: Vec<_> = best.into_values().collect();
+    deduped.sort_by(|a, b| {
+        a.score
+            .partial_cmp(&b.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    deduped.truncate(limit);
+    deduped
+        .into_iter()
+        .map(|r| SearchResult {
+            id: r.doc_id,
+            title: r.doc_title,
+            path: r.doc_path,
+            score: r.score,
+        })
+        .collect()
+}
+
+// ── backend factory functions ─────────────────────────────────────────────────
+
+/// Open or create an in-memory backend.
+///
+/// Data is not persisted to disk — all state is lost when the process exits.
+/// Use as a fallback when no storage feature is compiled in, or in tests.
+pub fn open_in_memory() -> Arc<dyn RetrieveStore + Send + Sync> {
+    Arc::new(InMemoryStore::new())
+}
+
+/// Open or create a SQLite FTS-only backend at `db_path`.
+///
+/// The SQLite file is created lazily on first use.
+/// Call [`open_sqlite_vec`] instead to enable vector search.
+#[cfg(feature = "sqlite-store")]
+pub fn open_sqlite_fts(db_path: &Path) -> Arc<dyn RetrieveStore + Send + Sync> {
+    Arc::new(SqliteStore::new_fts_only(db_path.to_owned()))
+}
+
+/// Open or create a SQLite + sqlite-vec backend at `db_path` with `dim`-dimensional embeddings.
+#[cfg(feature = "sqlite-store")]
+pub fn open_sqlite_vec(db_path: &Path, dim: u32) -> Result<Arc<dyn RetrieveStore + Send + Sync>> {
+    Ok(Arc::new(SqliteStore::new_with_vec(db_path.to_owned(), dim)?))
+}
+
+/// Open or create a LanceDB backend under `data_dir` with `dim`-dimensional embeddings.
+#[cfg(feature = "lancedb-store")]
+pub fn open_lancedb(data_dir: &Path, dim: u32) -> Result<Arc<dyn RetrieveStore + Send + Sync>> {
+    Ok(Arc::new(LanceDbBackend::new(data_dir, dim)?))
 }

--- a/crates/sapphire-retrieve/src/db.rs
+++ b/crates/sapphire-retrieve/src/db.rs
@@ -358,7 +358,10 @@ impl RetrieveDb {
     /// # Deprecation
     ///
     /// Prefer the free function [`dedup_chunk_results`] instead.
-    #[deprecated(since = "0.7.0", note = "use the free function `dedup_chunk_results` instead")]
+    #[deprecated(
+        since = "0.7.0",
+        note = "use the free function `dedup_chunk_results` instead"
+    )]
     pub fn dedup_chunk_results(results: Vec<ChunkSearchResult>, limit: usize) -> Vec<SearchResult> {
         dedup_chunk_results(results, limit)
     }
@@ -476,7 +479,10 @@ pub fn open_sqlite_fts(db_path: &Path) -> Arc<dyn RetrieveStore + Send + Sync> {
 /// Open or create a SQLite + sqlite-vec backend at `db_path` with `dim`-dimensional embeddings.
 #[cfg(feature = "sqlite-store")]
 pub fn open_sqlite_vec(db_path: &Path, dim: u32) -> Result<Arc<dyn RetrieveStore + Send + Sync>> {
-    Ok(Arc::new(SqliteStore::new_with_vec(db_path.to_owned(), dim)?))
+    Ok(Arc::new(SqliteStore::new_with_vec(
+        db_path.to_owned(),
+        dim,
+    )?))
 }
 
 /// Open or create a LanceDB backend under `data_dir` with `dim`-dimensional embeddings.

--- a/crates/sapphire-retrieve/src/lib.rs
+++ b/crates/sapphire-retrieve/src/lib.rs
@@ -12,12 +12,12 @@ pub mod vector_store;
 
 pub use chunker::{Chunker, JsonChunker, MarkdownChunker, TextChunk};
 pub use config::{EmbeddingConfig, HybridConfig, RetrieveConfig, VectorDb};
+pub use db::open_in_memory;
+#[cfg(feature = "lancedb-store")]
+pub use db::open_lancedb;
 pub use db::{Document, RetrieveDb, SearchResult, dedup_chunk_results};
 #[cfg(feature = "sqlite-store")]
 pub use db::{open_sqlite_fts, open_sqlite_vec};
-#[cfg(feature = "lancedb-store")]
-pub use db::open_lancedb;
-pub use db::open_in_memory;
 pub use embed::{Embedder, EmbedderConfig, build_embedder};
 pub use error::{Error, Result};
 pub use retrieve_store::RetrieveStore;

--- a/crates/sapphire-retrieve/src/lib.rs
+++ b/crates/sapphire-retrieve/src/lib.rs
@@ -12,7 +12,12 @@ pub mod vector_store;
 
 pub use chunker::{Chunker, JsonChunker, MarkdownChunker, TextChunk};
 pub use config::{EmbeddingConfig, HybridConfig, RetrieveConfig, VectorDb};
-pub use db::{Document, RetrieveDb, SearchResult};
+pub use db::{Document, RetrieveDb, SearchResult, dedup_chunk_results};
+#[cfg(feature = "sqlite-store")]
+pub use db::{open_sqlite_fts, open_sqlite_vec};
+#[cfg(feature = "lancedb-store")]
+pub use db::open_lancedb;
+pub use db::open_in_memory;
 pub use embed::{Embedder, EmbedderConfig, build_embedder};
 pub use error::{Error, Result};
 pub use retrieve_store::RetrieveStore;

--- a/crates/sapphire-retrieve/src/sqlite_store.rs
+++ b/crates/sapphire-retrieve/src/sqlite_store.rs
@@ -380,7 +380,7 @@ pub(crate) fn open_or_init(db_path: &Path) -> Result<Connection> {
     })
 }
 
-pub(crate) fn wipe_db_files(db_path: &Path) {
+pub fn wipe_db_files(db_path: &Path) {
     let base = db_path.to_string_lossy();
     for suffix in ["", "-wal", "-shm"] {
         let _ = std::fs::remove_file(format!("{base}{suffix}"));

--- a/crates/sapphire-workspace-cli/src/mcp.rs
+++ b/crates/sapphire-workspace-cli/src/mcp.rs
@@ -10,8 +10,8 @@ use rmcp::{
     schemars, tool, tool_handler, tool_router,
     transport::stdio,
 };
-use sapphire_workspace::{UserConfig, Workspace, WorkspaceState};
 use sapphire_retrieve::dedup_chunk_results;
+use sapphire_workspace::{UserConfig, Workspace, WorkspaceState};
 
 use crate::WORKSPACE_CTX;
 use serde::Deserialize;

--- a/crates/sapphire-workspace-cli/src/mcp.rs
+++ b/crates/sapphire-workspace-cli/src/mcp.rs
@@ -10,7 +10,8 @@ use rmcp::{
     schemars, tool, tool_handler, tool_router,
     transport::stdio,
 };
-use sapphire_workspace::{RetrieveDb, UserConfig, Workspace, WorkspaceState};
+use sapphire_workspace::{UserConfig, Workspace, WorkspaceState};
+use sapphire_retrieve::dedup_chunk_results;
 
 use crate::WORKSPACE_CTX;
 use serde::Deserialize;
@@ -166,7 +167,7 @@ impl RecallServer {
                         .retrieve_db()
                         .search_similar(&query_vec, limit * 3)
                         .map_err(anyhow::Error::msg)?;
-                    let results = RetrieveDb::dedup_chunk_results(raw, limit);
+                    let results = dedup_chunk_results(raw, limit);
                     return Ok(serde_json::to_string_pretty(&results)?);
                 }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashSet, path::Path};
+use std::{collections::HashSet, path::Path, sync::Arc};
 
-use sapphire_retrieve::{Chunker, Document, JsonChunker, RetrieveDb};
+use sapphire_retrieve::{Chunker, Document, JsonChunker, RetrieveStore};
 
 use crate::{error::Result, workspace::Workspace};
 
@@ -47,7 +47,10 @@ pub fn path_to_doc_id(path: &Path) -> i64 {
 /// text (no JSON syntax noise), and each chunk's `line` value in
 /// [`ChunkSearchResult`](sapphire_retrieve::ChunkSearchResult) is the 0-based
 /// source line number of that message in the original file.
-pub fn sync_workspace(workspace: &Workspace, retrieve_db: &RetrieveDb) -> Result<(usize, usize)> {
+pub fn sync_workspace(
+    workspace: &Workspace,
+    retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
+) -> Result<(usize, usize)> {
     let existing_ids: HashSet<i64> = retrieve_db
         .document_ids()
         .unwrap_or_default()
@@ -169,7 +172,7 @@ pub fn sync_workspace(workspace: &Workspace, retrieve_db: &RetrieveDb) -> Result
 /// much cheaper for periodic background refreshes.
 pub fn sync_workspace_incremental(
     workspace: &Workspace,
-    retrieve_db: &RetrieveDb,
+    retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
 ) -> Result<(usize, usize)> {
     let known_mtimes = retrieve_db.file_mtimes().unwrap_or_default();
     let existing_ids: HashSet<i64> = retrieve_db

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,11 @@ pub use sapphire_retrieve::db::SCHEMA_VERSION as RETRIEVE_SCHEMA_VERSION;
 pub use sapphire_retrieve::lancedb_store;
 pub use sapphire_retrieve::{
     Chunk, ChunkSearchResult, Document, Embedder, EmbedderConfig, Error as RetrieveError,
-    RetrieveDb, SearchResult, VecInfo, build_embedder,
+    RetrieveStore, SearchResult, VecInfo, build_embedder, dedup_chunk_results,
 };
+// RetrieveDb is kept for backwards compatibility; prefer RetrieveStore + factory functions.
+#[allow(deprecated)]
+pub use sapphire_retrieve::RetrieveDb;
 
 // Re-export sapphire-sync public API.
 #[cfg(feature = "git-sync")]

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -1,9 +1,14 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "sqlite-store")]
 use sapphire_retrieve::db::SCHEMA_VERSION;
-use sapphire_retrieve::{Document, Embedder, RetrieveDb, SearchResult};
+use sapphire_retrieve::{dedup_chunk_results, Document, Embedder, RetrieveStore, SearchResult};
+#[cfg(feature = "sqlite-store")]
+use sapphire_retrieve::{open_sqlite_fts, open_sqlite_vec};
+#[cfg(feature = "lancedb-store")]
+use sapphire_retrieve::open_lancedb;
 use tokio::sync::OnceCell;
 
 use crate::{
@@ -44,7 +49,7 @@ pub struct RetrieveParams<'a> {
 /// An open workspace paired with its lazily-initialised search infrastructure.
 pub struct WorkspaceState {
     pub workspace: Workspace,
-    retrieve_db: RetrieveDb,
+    retrieve_db: Mutex<Arc<dyn RetrieveStore + Send + Sync>>,
     embedder: OnceCell<Option<Box<dyn Embedder + Send + Sync>>>,
     sync_backend: Option<Box<dyn sapphire_sync::SyncBackend + Send + Sync>>,
 }
@@ -66,10 +71,10 @@ impl WorkspaceState {
     /// [`sapphire_sync::GitSync`] backend if the workspace root is inside a
     /// git repository.  Silently falls back to no backend if git is not found.
     pub fn open(workspace: Workspace) -> Result<Self> {
-        let retrieve_db = RetrieveDb::open(&workspace.retrieve_db_path())?;
+        let backend = Self::open_initial_backend(&workspace);
         let mut state = Self {
+            retrieve_db: Mutex::new(backend),
             workspace,
-            retrieve_db,
             embedder: OnceCell::new(),
             sync_backend: None,
         };
@@ -82,15 +87,17 @@ impl WorkspaceState {
 
     /// Delete and recreate the retrieve DB from scratch.
     pub fn rebuild(workspace: Workspace) -> Result<Self> {
-        let retrieve_db = RetrieveDb::rebuild(&workspace.retrieve_db_path())?;
+        #[cfg(feature = "sqlite-store")]
+        sapphire_retrieve::sqlite_store::wipe_db_files(&workspace.retrieve_db_path());
         #[cfg(feature = "lancedb-store")]
         {
             use sapphire_retrieve::lancedb_store;
             let _ = std::fs::remove_dir_all(lancedb_store::data_dir(&workspace.cache_dir()));
         }
+        let backend = Self::open_initial_backend(&workspace);
         Ok(Self {
+            retrieve_db: Mutex::new(backend),
             workspace,
-            retrieve_db,
             embedder: OnceCell::new(),
             sync_backend: None,
         })
@@ -162,8 +169,12 @@ impl WorkspaceState {
         self.sync_backend = Some(backend);
     }
 
-    pub fn retrieve_db(&self) -> &RetrieveDb {
-        &self.retrieve_db
+    /// Clone the active retrieve backend as an `Arc<dyn RetrieveStore>`.
+    ///
+    /// The lock is released immediately after cloning the `Arc`, so long-running
+    /// operations do not block other threads from checking the backend state.
+    pub fn retrieve_db(&self) -> Arc<dyn RetrieveStore + Send + Sync> {
+        Arc::clone(&*self.retrieve_db.lock().unwrap())
     }
 
     pub fn embedder(&self) -> Option<&dyn Embedder> {
@@ -197,15 +208,16 @@ impl WorkspaceState {
             .unwrap_or_default();
         let doc_id = path_to_doc_id(path);
 
-        self.retrieve_db.upsert_file(&path_str, mtime)?;
-        self.retrieve_db.upsert_document(&Document {
+        let db = self.retrieve_db();
+        db.upsert_file(&path_str, mtime)?;
+        db.upsert_document(&Document {
             id: doc_id,
             title,
             body,
             path: path_str,
             chunks: None,
         })?;
-        self.retrieve_db.rebuild_fts()?;
+        db.rebuild_fts()?;
 
         if let Some(sync) = &self.sync_backend {
             sync.add_file(path)?;
@@ -220,9 +232,10 @@ impl WorkspaceState {
         let path_str = path.to_string_lossy().into_owned();
         let doc_id = path_to_doc_id(path);
 
-        self.retrieve_db.remove_document(doc_id)?;
-        self.retrieve_db.remove_file(&path_str)?;
-        self.retrieve_db.rebuild_fts()?;
+        let db = self.retrieve_db();
+        db.remove_document(doc_id)?;
+        db.remove_file(&path_str)?;
+        db.rebuild_fts()?;
 
         if let Some(sync) = &self.sync_backend {
             sync.remove_file(path)?;
@@ -328,71 +341,18 @@ impl WorkspaceState {
 
     /// Initialise the vector backend (sync). Idempotent.
     pub fn load_retrieve_backend(&self, config: &UserConfig) -> Result<()> {
-        let Some(retrieve) = &config.retrieve else {
+        let Some((vector_db, dim)) = Self::extract_vector_config(config) else {
             return Ok(());
         };
-        let Some(embed_cfg) = &retrieve.embedding else {
-            return Ok(());
-        };
-        if !embed_cfg.enabled {
-            return Ok(());
+        if let Some(backend) = self.make_vector_backend(vector_db, dim)? {
+            *self.retrieve_db.lock().unwrap() = backend;
         }
-        let Some(dim) = embed_cfg.dimension else {
-            return Ok(());
-        };
-        self.init_vector_backend(retrieve.db, dim)
+        Ok(())
     }
 
     /// Async version of [`load_retrieve_backend`](Self::load_retrieve_backend).
     pub async fn load_retrieve_backend_async(&self, config: &UserConfig) -> Result<()> {
-        let Some(retrieve) = &config.retrieve else {
-            return Ok(());
-        };
-        let Some(embed_cfg) = &retrieve.embedding else {
-            return Ok(());
-        };
-        if !embed_cfg.enabled {
-            return Ok(());
-        }
-        let Some(dim) = embed_cfg.dimension else {
-            return Ok(());
-        };
-        let vector_db = retrieve.db;
-
-        #[cfg(feature = "lancedb-store")]
-        if vector_db == VectorDb::LanceDb {
-            use sapphire_retrieve::lancedb_store;
-            let lancedb_dir = lancedb_store::data_dir(&self.workspace.cache_dir());
-            self.retrieve_db.init_lancedb(&lancedb_dir, dim)?;
-            return Ok(());
-        }
-
-        self.init_vector_backend(vector_db, dim)
-    }
-
-    fn init_vector_backend(&self, vector_db: VectorDb, dim: u32) -> Result<()> {
-        match vector_db {
-            VectorDb::None => {}
-            #[cfg(feature = "sqlite-store")]
-            VectorDb::SqliteVec => {
-                self.retrieve_db.init_sqlite_vec(dim)?;
-            }
-            #[cfg(not(feature = "sqlite-store"))]
-            VectorDb::SqliteVec => {
-                return Err(crate::error::Error::SqliteStoreNotEnabled);
-            }
-            #[cfg(feature = "lancedb-store")]
-            VectorDb::LanceDb => {
-                use sapphire_retrieve::lancedb_store;
-                let lancedb_dir = lancedb_store::data_dir(&self.workspace.cache_dir());
-                self.retrieve_db.init_lancedb(&lancedb_dir, dim)?;
-            }
-            #[cfg(not(feature = "lancedb-store"))]
-            VectorDb::LanceDb => {
-                return Err(crate::error::Error::LanceDbNotEnabled);
-            }
-        }
-        Ok(())
+        self.load_retrieve_backend(config)
     }
 
     // ── embedder ──────────────────────────────────────────────────────────────
@@ -442,7 +402,7 @@ impl WorkspaceState {
 
     /// Scan the workspace and incrementally sync all files into the retrieve DB.
     pub fn sync(&self) -> Result<(usize, usize)> {
-        sync_workspace(&self.workspace, &self.retrieve_db)
+        sync_workspace(&self.workspace, self.retrieve_db())
     }
 
     /// Run the periodic sync cycle: git sync (if configured) followed by an
@@ -458,14 +418,14 @@ impl WorkspaceState {
         if let Some(backend) = &self.sync_backend {
             backend.sync()?;
         }
-        sync_workspace_incremental(&self.workspace, &self.retrieve_db)
+        sync_workspace_incremental(&self.workspace, self.retrieve_db())
     }
 
     /// Sync and, when embedding is configured, embed pending chunks.
     ///
     /// Returns `(upserted, removed, embedded)`.
     pub async fn sync_and_embed(&self, config: &UserConfig) -> Result<(usize, usize, usize)> {
-        let (upserted, removed) = sync_workspace(&self.workspace, &self.retrieve_db)?;
+        let (upserted, removed) = sync_workspace(&self.workspace, self.retrieve_db())?;
 
         let embed_cfg = config.retrieve.as_ref().and_then(|r| r.embedding.as_ref());
         let Some(embed_cfg) = embed_cfg else {
@@ -482,7 +442,7 @@ impl WorkspaceState {
             return Ok((upserted, removed, 0));
         };
 
-        let embedded = self.retrieve_db.embed_pending(embedder, |_, _| {})?;
+        let embedded = self.retrieve_db().embed_pending(embedder, &|_, _| {})?;
         Ok((upserted, removed, embedded))
     }
 
@@ -504,22 +464,20 @@ impl WorkspaceState {
         let Some(embedder) = self.embedder() else {
             return Ok(0);
         };
-        Ok(self.retrieve_db.embed_pending(embedder, on_progress)?)
+        Ok(self.retrieve_db().embed_pending(embedder, &on_progress)?)
     }
 
     // ── info ──────────────────────────────────────────────────────────────────
 
     pub fn db_info(&self) -> Result<DbInfo> {
         let db_path = self.workspace.retrieve_db_path();
-        let document_count = self.retrieve_db.document_count().unwrap_or(0);
-        let vec_info = self
-            .retrieve_db
-            .vec_info()
-            .unwrap_or(sapphire_retrieve::VecInfo {
-                embedding_dim: 0,
-                vector_count: 0,
-                pending_count: 0,
-            });
+        let db = self.retrieve_db();
+        let document_count = db.document_count().unwrap_or(0);
+        let vec_info = db.vec_info().unwrap_or(sapphire_retrieve::VecInfo {
+            embedding_dim: 0,
+            vector_count: 0,
+            pending_count: 0,
+        });
         Ok(DbInfo {
             db_path,
             #[cfg(feature = "sqlite-store")]
@@ -578,7 +536,7 @@ impl WorkspaceState {
     }
 
     fn search_fts_internal(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
-        Ok(self.retrieve_db.search_fts(query, limit)?)
+        Ok(self.retrieve_db().search_fts(query, limit)?)
     }
 
     fn search_semantic_internal(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
@@ -587,8 +545,8 @@ impl WorkspaceState {
         let query_vec = query_vecs.into_iter().next().ok_or_else(|| {
             sapphire_retrieve::Error::Embed("embedder returned empty result".into())
         })?;
-        let raw = self.retrieve_db.search_similar(&query_vec, limit * 3)?;
-        Ok(RetrieveDb::dedup_chunk_results(raw, limit))
+        let raw = self.retrieve_db().search_similar(&query_vec, limit * 3)?;
+        Ok(dedup_chunk_results(raw, limit))
     }
 
     fn search_hybrid_internal(
@@ -656,5 +614,58 @@ impl WorkspaceState {
             .into_iter()
             .filter(|r| r.path.starts_with(prefix_str.as_ref()))
             .collect()
+    }
+
+    // ── private helpers ───────────────────────────────────────────────────────
+
+    /// Create the initial (non-vector) backend appropriate for the compiled features.
+    fn open_initial_backend(workspace: &Workspace) -> Arc<dyn RetrieveStore + Send + Sync> {
+        #[cfg(feature = "sqlite-store")]
+        {
+            open_sqlite_fts(&workspace.retrieve_db_path())
+        }
+        #[cfg(not(feature = "sqlite-store"))]
+        {
+            let _ = workspace;
+            sapphire_retrieve::open_in_memory()
+        }
+    }
+
+    /// Extract `(vector_db, embedding_dim)` from config if vector search is enabled.
+    fn extract_vector_config(config: &UserConfig) -> Option<(VectorDb, u32)> {
+        let retrieve = config.retrieve.as_ref()?;
+        let embed_cfg = retrieve.embedding.as_ref()?;
+        if !embed_cfg.enabled {
+            return None;
+        }
+        let dim = embed_cfg.dimension?;
+        Some((retrieve.db, dim))
+    }
+
+    /// Construct a fully-initialised vector backend for the given `vector_db` kind.
+    ///
+    /// Returns `None` when `vector_db` is `VectorDb::None` (no vector search).
+    fn make_vector_backend(
+        &self,
+        vector_db: VectorDb,
+        dim: u32,
+    ) -> Result<Option<Arc<dyn RetrieveStore + Send + Sync>>> {
+        match vector_db {
+            VectorDb::None => Ok(None),
+            #[cfg(feature = "sqlite-store")]
+            VectorDb::SqliteVec => {
+                Ok(Some(open_sqlite_vec(&self.workspace.retrieve_db_path(), dim)?))
+            }
+            #[cfg(not(feature = "sqlite-store"))]
+            VectorDb::SqliteVec => Err(crate::error::Error::SqliteStoreNotEnabled),
+            #[cfg(feature = "lancedb-store")]
+            VectorDb::LanceDb => {
+                use sapphire_retrieve::lancedb_store;
+                let lancedb_dir = lancedb_store::data_dir(&self.workspace.cache_dir());
+                Ok(Some(open_lancedb(&lancedb_dir, dim)?))
+            }
+            #[cfg(not(feature = "lancedb-store"))]
+            VectorDb::LanceDb => Err(crate::error::Error::LanceDbNotEnabled),
+        }
     }
 }

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -4,11 +4,11 @@ use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "sqlite-store")]
 use sapphire_retrieve::db::SCHEMA_VERSION;
-use sapphire_retrieve::{dedup_chunk_results, Document, Embedder, RetrieveStore, SearchResult};
-#[cfg(feature = "sqlite-store")]
-use sapphire_retrieve::{open_sqlite_fts, open_sqlite_vec};
 #[cfg(feature = "lancedb-store")]
 use sapphire_retrieve::open_lancedb;
+use sapphire_retrieve::{Document, Embedder, RetrieveStore, SearchResult, dedup_chunk_results};
+#[cfg(feature = "sqlite-store")]
+use sapphire_retrieve::{open_sqlite_fts, open_sqlite_vec};
 use tokio::sync::OnceCell;
 
 use crate::{
@@ -653,9 +653,10 @@ impl WorkspaceState {
         match vector_db {
             VectorDb::None => Ok(None),
             #[cfg(feature = "sqlite-store")]
-            VectorDb::SqliteVec => {
-                Ok(Some(open_sqlite_vec(&self.workspace.retrieve_db_path(), dim)?))
-            }
+            VectorDb::SqliteVec => Ok(Some(open_sqlite_vec(
+                &self.workspace.retrieve_db_path(),
+                dim,
+            )?)),
             #[cfg(not(feature = "sqlite-store"))]
             VectorDb::SqliteVec => Err(crate::error::Error::SqliteStoreNotEnabled),
             #[cfg(feature = "lancedb-store")]


### PR DESCRIPTION
## Summary

Aligns `WorkspaceState.retrieve_db` with the existing `embedder` and `sync_backend` fields by making it a trait object (`Mutex<Arc<dyn RetrieveStore + Send + Sync>>`) instead of the concrete `RetrieveDb` type.

**Motivation:** `RetrieveDb` was a historical artifact from when SQLite was the only backend. Now that SQLite, LanceDB, and in-memory are all selectable, the backend selection belongs at the same level of abstraction as `embedder` and `sync_backend`.

### Changes in `sapphire-retrieve`

- Add backend factory functions returning `Arc<dyn RetrieveStore + Send + Sync>` (feature-gated):
  - `open_sqlite_fts(path)` — SQLite FTS-only
  - `open_sqlite_vec(path, dim)` — SQLite + sqlite-vec
  - `open_lancedb(dir, dim)` — LanceDB
  - `open_in_memory()` — in-memory fallback
- Move `RetrieveDb::dedup_chunk_results` to a crate-level free function; keep a deprecated shim on `RetrieveDb` for backwards compatibility
- Expose `wipe_db_files` as `pub` (was `pub(crate)`)
- Re-export new symbols from `lib.rs`

### Changes in `sapphire-workspace`

- `WorkspaceState.retrieve_db`: `RetrieveDb` → `Mutex<Arc<dyn RetrieveStore>>`
- `retrieve_db()` accessor returns a cloned `Arc<dyn RetrieveStore>` (lock released immediately, same pattern as the old `RetrieveDb::store()`)
- Two-phase init eliminated: `load_retrieve_backend` constructs the vector backend via factory functions and swaps it into the Mutex in one step
- `load_retrieve_backend_async` simplified to a thin wrapper around the sync version
- `init_vector_backend` replaced by `make_vector_backend` returning `Option<Arc<dyn RetrieveStore>>`
- `sync_workspace` / `sync_workspace_incremental` in `indexer.rs` accept `Arc<dyn RetrieveStore + Send + Sync>` instead of `&RetrieveDb`
- `mcp.rs`: `RetrieveDb::dedup_chunk_results` → free `dedup_chunk_results`
- `lib.rs`: re-export `RetrieveStore` and `dedup_chunk_results`; keep `RetrieveDb` re-export (deprecated) for backwards compatibility

## Test plan

- [ ] `cargo check --no-default-features` passes
- [ ] `cargo check --features sqlite-store` passes
- [ ] `cargo check --features lancedb-store` passes
- [ ] `cargo check --all-features` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --all-features --locked` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)