### PR TITLE
feat: enable sqlite-store feature by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ keywords = ["workspace", "markdown", "search", "sync"]
 categories = ["filesystem", "database"]
 
 [features]
-default = ["lancedb-store", "fastembed-embed", "git-sync"]
+default = ["sqlite-store", "lancedb-store", "fastembed-embed", "git-sync"]
 sqlite-store    = ["sapphire-retrieve/sqlite-store"]
 lancedb-store   = ["sapphire-retrieve/lancedb-store"]
 fastembed-embed = ["sapphire-retrieve/fastembed-embed"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Workspace management library for indexing, search, and sync of Markdown document
 |---|---|---|
 | `lancedb-store` | LanceDB vector backend for semantic search | yes |
 | `fastembed-embed` | On-device embedding via FastEmbed | yes |
-| `sqlite-store` | SQLite FTS5 + sqlite-vec backend | no |
+| `sqlite-store` | SQLite FTS5 + sqlite-vec backend | yes |
 | `git-sync` | Git-based workspace synchronisation via `sapphire-sync` | yes |
 
 ## Quick start


### PR DESCRIPTION
## Summary

- Add `sqlite-store` to the `default` feature set in `Cargo.toml` so the SQLite FTS5 + sqlite-vec backend is enabled out of the box
- Update the README feature table to mark `sqlite-store` as enabled by default (`yes`)

## Test plan

- [ ] `cargo build` succeeds without any feature flags
- [ ] `cargo test` passes with the default feature set
- [ ] Verify `sqlite-store` functionality works end-to-end after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)