### PR TITLE
release: sapphire-workspace 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `sapphire-workspace` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-04-11
+
+### Changed
+
+- `WorkspaceState::retrieve_db()` now returns `Arc<dyn RetrieveStore>` instead of the concrete `RetrieveDb` type.  Callers that previously called methods on `RetrieveDb` directly should switch to the `RetrieveStore` trait interface.
+- `sapphire-retrieve`: added backend factory functions `open_sqlite_fts`, `open_sqlite_vec`, `open_lancedb`, `open_in_memory` — each returns `Arc<dyn RetrieveStore + Send + Sync>` (feature-gated as before).
+- `sapphire-retrieve`: `RetrieveDb::dedup_chunk_results` moved to a crate-level free function `dedup_chunk_results`; the method on `RetrieveDb` is kept as a deprecated shim.
+- `sapphire-retrieve`: `wipe_db_files` is now `pub` (was `pub(crate)`).
+- `sqlite-store` feature is now enabled by default (previously opt-in); the default feature set now includes `sqlite-store`, `lancedb-store`, `fastembed-embed`, and `git-sync`.
+
+### Deprecated
+
+- `RetrieveDb` — use `Arc<dyn RetrieveStore>` returned by `WorkspaceState::retrieve_db()` instead.  `RetrieveDb` re-export is kept for one release to ease migration.
+
 ## [0.6.0] - 2026-04-11
 
 ### Added
@@ -96,6 +110,7 @@ Internal repository restructure; no public API changes.
 - `fastembed-embed`, `lancedb-store`, `sqlite-store`, `git-sync` feature flags.
 - Re-exports of `sapphire-retrieve` and `sapphire-sync` public APIs.
 
+[0.7.0]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.6.0...workspace-v0.7.0
 [0.6.0]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.5.1...workspace-v0.6.0
 [0.5.1]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.5.0...workspace-v0.5.1
 [0.5.0]: https://github.com/fluo10/sapphire-journal/compare/workspace-v0.4.0...workspace-v0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 description = "Workspace management library for indexing, search, and sync of file-based documents"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-workspace"
@@ -50,8 +50,8 @@ fastembed-embed = ["sapphire-retrieve/fastembed-embed"]
 git-sync        = ["sapphire-sync/git"]
 
 [dependencies]
-sapphire-retrieve = { version = "0.6.0", path = "crates/sapphire-retrieve", default-features = false }
-sapphire-sync     = { version = "0.6.0", path = "crates/sapphire-sync", default-features = false }
+sapphire-retrieve = { version = "0.7.0", path = "crates/sapphire-retrieve", default-features = false }
+sapphire-sync     = { version = "0.7.0", path = "crates/sapphire-sync", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Workspace management library for indexing, search, and sync of Markdown document
 
 ```toml
 [dependencies]
-sapphire-workspace = "0.6"
+sapphire-workspace = "0.7"
 ```
 
 ### Initialise a workspace

--- a/crates/sapphire-workspace-cli/Cargo.toml
+++ b/crates/sapphire-workspace-cli/Cargo.toml
@@ -19,7 +19,7 @@ fastembed-embed = ["sapphire-workspace/fastembed-embed"]
 git-sync        = ["sapphire-workspace/git-sync"]
 
 [dependencies]
-sapphire-workspace = { version = "0.6.0", path = "../..", default-features = false }
+sapphire-workspace = { version = "0.7.0", path = "../..", default-features = false }
 clap.workspace = true
 anyhow.workspace = true
 serde.workspace = true


### PR DESCRIPTION
## Summary

- `WorkspaceState::retrieve_db()` の戻り値を `RetrieveDb` から `Arc<dyn RetrieveStore>` に変更（バックエンドをトレイトオブジェクトに統一）
- `sapphire-retrieve` にバックエンドファクトリ関数を追加（`open_sqlite_fts` / `open_sqlite_vec` / `open_lancedb` / `open_in_memory`）
- `sqlite-store` フィーチャをデフォルト有効化
- `RetrieveDb` を deprecated に（互換性のため 1 リリース保持）
- バージョン: 0.6.0 → 0.7.0

## Changes

- `Cargo.toml` (workspace): version bump 0.6.0 → 0.7.0
- `crates/sapphire-workspace-cli/Cargo.toml`: sapphire-workspace 依存バージョン更新
- `README.md`: Quick start のバージョン指定を `"0.7"` に更新
- `CHANGELOG.md`: v0.7.0 エントリ追加

## Release checklist

- [ ] CI passes
- [ ] crates.io publish (自動: `sapphire-retrieve` → `sapphire-sync` → `sapphire-workspace`)
- [ ] GitHub Release + tag `v0.7.0` 作成（マージ後に自動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)