### PR TITLE
release: sapphire-workspace 0.7.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         run: choco install protoc
 
       - name: Build
-        run: cargo build -p sapphire-workspace-cli --release --locked --target ${{ matrix.target }}
+        run: cargo build -p sapphire-workspace-cli --release --target ${{ matrix.target }}
 
       - name: Stage binary
         shell: bash


### PR DESCRIPTION
## Summary

- Replace `RetrieveDb` with `Arc<dyn RetrieveStore>` in `WorkspaceState` — backend is now a trait object, consistent with `embedder` and `sync_backend` fields
- Add backend factory functions to `sapphire-retrieve`: `open_sqlite_fts`, `open_sqlite_vec`, `open_lancedb`, `open_in_memory`
- Enable `sqlite-store` feature by default
- Deprecate `RetrieveDb` (re-exported for one release as a migration shim)
- Fix release CI: remove `--locked` from cargo build (repo is library-first; `Cargo.lock` is gitignored)

## Changelog

See [CHANGELOG.md](CHANGELOG.md) for the full v0.7.0 entry.

## Release checklist

- [ ] CI passes
- [ ] crates.io publish — `sapphire-retrieve` → `sapphire-sync` → `sapphire-workspace` (automated on merge)
- [ ] GitHub Release + tag `v0.7.0` created (automated on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)