### PR TITLE
Add workflow to auto-merge Dependabot patch updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,22 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+      - name: Enable auto-merge for patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `dependabot-auto-merge.yml` workflow that enables auto-merge when Dependabot opens a patch version PR
- Only patch updates (`version-update:semver-patch`) are auto-merged; minor and major updates still require manual review

## How it works

1. Triggered on any pull request from `dependabot[bot]`
2. Uses `dependabot/fetch-metadata` to read the update type
3. If patch update: runs `gh pr merge --auto --squash`, which merges automatically once all required status checks pass

## Required setup

Enable **Allow auto-merge** in each repository's Settings → General.

🤖 Generated with [Claude Code](https://claude.com/claude-code)