### PR TITLE
release: v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `sapphire-workspace` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-04-12
+
+### Fixed
+
+- `sapphire-sync`: SSH push and fetch now authenticate correctly via libgit2.  Previously `remote.push()` / `remote.fetch()` were called without `RemoteCallbacks`, causing push to silently fail against SSH remotes.  Authentication is now attempted in order: ssh-agent → `~/.ssh/id_ed25519` → `~/.ssh/id_ecdsa` → `~/.ssh/id_rsa`. (#30)
+
 ## [0.7.0] - 2026-04-11
 
 ### Changed
@@ -110,6 +116,7 @@ Internal repository restructure; no public API changes.
 - `fastembed-embed`, `lancedb-store`, `sqlite-store`, `git-sync` feature flags.
 - Re-exports of `sapphire-retrieve` and `sapphire-sync` public APIs.
 
+[0.7.1]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.7.0...workspace-v0.7.1
 [0.7.0]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.6.0...workspace-v0.7.0
 [0.6.0]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.5.1...workspace-v0.6.0
 [0.5.1]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.5.0...workspace-v0.5.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 description = "Workspace management library for indexing, search, and sync of file-based documents"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-workspace"
@@ -51,8 +51,8 @@ fastembed-embed = ["sapphire-retrieve/fastembed-embed"]
 git-sync        = ["sapphire-sync/git"]
 
 [dependencies]
-sapphire-retrieve = { version = "0.7.0", path = "crates/sapphire-retrieve", default-features = false }
-sapphire-sync     = { version = "0.7.0", path = "crates/sapphire-sync", default-features = false }
+sapphire-retrieve = { version = "0.7.1", path = "crates/sapphire-retrieve", default-features = false }
+sapphire-sync     = { version = "0.7.1", path = "crates/sapphire-sync", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/sapphire-workspace-cli/Cargo.toml
+++ b/crates/sapphire-workspace-cli/Cargo.toml
@@ -19,7 +19,7 @@ fastembed-embed = ["sapphire-workspace/fastembed-embed"]
 git-sync        = ["sapphire-workspace/git-sync"]
 
 [dependencies]
-sapphire-workspace = { version = "0.7.0", path = "../..", default-features = false }
+sapphire-workspace = { version = "0.7.1", path = "../..", default-features = false }
 clap.workspace = true
 anyhow.workspace = true
 serde.workspace = true


### PR DESCRIPTION
## v0.7.1

### Fixed

- `sapphire-sync`: SSH push/fetch がサイレントに失敗する問題を修正 (#30)
  libgit2 に `RemoteCallbacks` を渡していなかったため SSH リモートへの push が常に失敗していた。ssh-agent → `id_ed25519` → `id_ecdsa` → `id_rsa` の順で認証を試みるよう対応。

### Changes

- `Cargo.toml`: `0.7.0` → `0.7.1`
- `CHANGELOG.md`: `[0.7.1]` エントリ追加

### API changes

なし（パッチリリース）

## Test plan

- [ ] `cargo check` が通ること
- [ ] SSH リモートに対して push が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)