### PR TITLE
ci(release): run cargo-publish in parallel with build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,22 +63,13 @@ jobs:
           name: sapphire-workspace-${{ matrix.target }}
           path: dist/
 
-  publish:
-    needs: build
+  cargo-publish:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
-
-      - name: Extract version from branch name
-        id: version
-        run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
-          VERSION="${BRANCH#release/}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -118,6 +109,23 @@ jobs:
           fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release:
+    needs: [build, cargo-publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Download build artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

- `publish` ジョブを `cargo-publish` と `release` の2ジョブに分割
- `cargo-publish` は `build` と並行して実行（`needs` なし）
- `release` は `needs: [build, cargo-publish]` で両方の完了後に GitHub Release を作成

## Test plan

- [ ] リリースブランチのPRをマージして、`cargo-publish` と `build` が並行実行されることを確認
- [ ] `release` ジョブが両方の完了後に GitHub Release を作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)