### PR TITLE
chore(release): v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to `sapphire-workspace` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-04-13
+
+### Fixed
+
+- `sapphire-sync`: SSH credentials callback no longer loops infinitely when `ssh-agent` returns a credential that fails authentication. The callback now tracks attempt index and cycles through methods (ssh-agent → key files) instead of retrying the same method. (#38)
+- `sapphire-sync`: remote push rejections are now logged via `tracing::warn` (previously silently ignored due to missing `push_update_reference` callback).
+
+### Added
+
+- `sapphire-sync`: `tracing` instrumentation in `sync_git` for observability (fetch/merge/push cycle start, early-return, push result).
+
 ## [0.8.0] - 2026-04-12
 
 ### Changed
@@ -133,6 +144,7 @@ Internal repository restructure; no public API changes.
 - `fastembed-embed`, `lancedb-store`, `sqlite-store`, `git-sync` feature flags.
 - Re-exports of `sapphire-retrieve` and `sapphire-sync` public APIs.
 
+[0.8.1]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.8.0...workspace-v0.8.1
 [0.8.0]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.7.1...workspace-v0.8.0
 [0.7.1]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.7.0...workspace-v0.7.1
 [0.7.0]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.6.0...workspace-v0.7.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 description = "Workspace management library for indexing, search, and sync of file-based documents"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-workspace"
@@ -52,8 +52,8 @@ fastembed-embed = ["sapphire-retrieve/fastembed-embed"]
 git-sync        = ["sapphire-sync/git"]
 
 [dependencies]
-sapphire-retrieve = { version = "0.8.0", path = "crates/sapphire-retrieve", default-features = false }
-sapphire-sync     = { version = "0.8.0", path = "crates/sapphire-sync", default-features = false }
+sapphire-retrieve = { version = "0.8.1", path = "crates/sapphire-retrieve", default-features = false }
+sapphire-sync     = { version = "0.8.1", path = "crates/sapphire-sync", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/sapphire-workspace-cli/Cargo.toml
+++ b/crates/sapphire-workspace-cli/Cargo.toml
@@ -19,7 +19,7 @@ fastembed-embed = ["sapphire-workspace/fastembed-embed"]
 git-sync        = ["sapphire-workspace/git-sync"]
 
 [dependencies]
-sapphire-workspace = { version = "0.8.0", path = "../..", default-features = false }
+sapphire-workspace = { version = "0.8.1", path = "../..", default-features = false }
 clap.workspace = true
 anyhow.workspace = true
 serde.workspace = true


### PR DESCRIPTION
## Summary

- Bump workspace version to 0.8.1
- Update CHANGELOG with fixes from #38 / #39

### Fixed
- `sapphire-sync`: SSH credentials callback infinite loop when ssh-agent credential fails authentication
- `sapphire-sync`: remote push rejections now logged via `tracing::warn`

### Added
- `sapphire-sync`: `tracing` instrumentation in `sync_git`

## Test plan

- [x] `cargo check` passes
- [ ] CI passes (fmt, clippy, test)
- [ ] Merge triggers release workflow (build, cargo publish, GitHub release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)