### PR TITLE
feat(retrieve): path-prefix filtering + chunk-level hybrid search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `sapphire-workspace` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed (breaking)
+
+- `sapphire-retrieve`: full-text search now indexes **chunks** (via `chunks_fts`) instead of whole documents. `search_fts`, `search_similar`, and `search_hybrid` all return `Vec<FileSearchResult>` — each file carries a `chunks` array with the matched line ranges (`line_start`, `line_end`), so MCP / AI callers can see *where* inside a file a match occurred without re-reading the whole document.
+- `sapphire-retrieve`: `SearchResult` / `ChunkSearchResult` / `dedup_chunk_results` / `merge_rrf` removed; replaced by `FileSearchResult` / `ChunkHit` / `merge_rrf_files`.
+- `sapphire-retrieve`: Query structs introduced (`FtsQuery`, `VectorQuery`, `HybridQuery`) with builder methods. All three take `query: &str` as a common field; `VectorQuery` / `HybridQuery` also accept an `Embedder` (mandatory for vector, optional for hybrid — `None` falls back to FTS-only). Callers no longer pre-compute embeddings.
+- `sapphire-retrieve`: `RetrieveStore::search_hybrid` added to the trait with a default implementation, and exposed on `RetrieveDb`.
+- `sapphire-retrieve`: `search_fts` / `search_similar` / `search_hybrid` accept an optional `path_prefix` that is pushed down to the backend (SQLite `GLOB`, LanceDB `only_if`), replacing the post-filter that previously lived in `WorkspaceState`.
+- `sapphire-retrieve`: chunk schema changed from `(line, column)` to `(line_start, line_end)` — inclusive line range. `TextChunk`, `Chunk`, and all backend schemas updated.
+- `sapphire-retrieve`: `documents.body` column / field dropped from storage (still used as chunker input when `Document::chunks` is `None`). SQLite `documents_fts` virtual table removed; LanceDB FTS now indexes `chunks_meta.text`.
+- `sapphire-retrieve`: **schema migration required.** SQLite databases on version `<4` are automatically wiped and recreated on first open (next sync re-indexes the workspace). LanceDB is bumped to `lancedb_v4/`; the old `lancedb_v3/` directory is no longer used and can be removed manually.
+
 ## [0.8.1] - 2026-04-13
 
 ### Fixed

--- a/crates/sapphire-retrieve/src/chunker.rs
+++ b/crates/sapphire-retrieve/src/chunker.rs
@@ -9,22 +9,19 @@
 //!
 //! # Source positions
 //!
-//! Each [`TextChunk`] carries the exact source position ([`line`] and
-//! [`column`]) of where that chunk begins in the original file.  The
-//! [`line`](TextChunk::line) value is stored in the `line` column of the
-//! database so [`ChunkSearchResult::line`][crate::vector_store::ChunkSearchResult::line]
-//! is always a 0-based **source line number**, regardless of file format.
-//!
-//! This lets a GUI jump directly to `line:column` in the source file, and
-//! render surrounding context (like `git diff`) without any extra lookup step.
+//! Each [`TextChunk`] carries the line range
+//! ([`line_start`](TextChunk::line_start), [`line_end`](TextChunk::line_end))
+//! that the chunk occupies in the original file (both values are 0-based and
+//! inclusive).  A GUI / AI client can use this range to jump to the chunk or
+//! fetch the surrounding context without scanning the whole file.
 //!
 //! ## Examples
 //!
-//! | Format | `line` | `column` |
-//! |--------|--------|---------|
-//! | Markdown paragraph | line of the first non-blank character | 0 |
-//! | JSONL line | line index of the JSON line | 0 |
-//! | JSON array element | line of the opening `{` | col of `{` |
+//! | Format | `line_start` | `line_end` |
+//! |--------|--------------|-----------|
+//! | Markdown paragraph | line of the first non-blank char | line of the last non-blank char |
+//! | JSONL line | line index of the JSON line | same |
+//! | JSON array element | line of the opening `{` | line of the closing `}` |
 //!
 //! # Example
 //!
@@ -33,34 +30,27 @@
 //!
 //! let md = MarkdownChunker;
 //! let chunks = md.chunk("My note", "First paragraph.\n\nSecond paragraph.");
-//! assert_eq!(chunks[0].line, 0);
-//! assert_eq!(chunks[1].line, 2);
+//! assert_eq!(chunks[0].line_start, 0);
+//! assert_eq!(chunks[1].line_start, 2);
 //!
 //! let json = JsonChunker;
 //! let jsonl = "{\"role\":\"user\",\"content\":\"Hello\"}\n{\"role\":\"assistant\",\"content\":\"Hi\"}";
 //! let chunks = json.chunk("chat.jsonl", jsonl);
-//! assert_eq!(chunks[0].line, 0);
-//! assert_eq!(chunks[1].line, 1);
+//! assert_eq!(chunks[0].line_start, 0);
+//! assert_eq!(chunks[1].line_start, 1);
 //! ```
 
-/// A single chunk of text extracted from a file, carrying its precise source
-/// location.
-///
-/// The [`line`](Self::line) field is stored in the `line` column of the
-/// database so `ChunkSearchResult::line` from a vector search is always a
-/// source line number that a GUI can navigate to directly.
+/// A single chunk of text extracted from a file, with the source line range it
+/// occupies (both 0-based, inclusive).
 #[derive(Debug, Clone)]
 pub struct TextChunk {
-    /// Zero-based line number in the source file where this chunk begins.
+    /// First source line of the chunk (inclusive, 0-based).
+    pub line_start: usize,
+    /// Last source line of the chunk (inclusive, 0-based).
     ///
-    /// This value is stored in the `line` column of the database.
-    pub line: usize,
-    /// Zero-based byte offset within `line` where this chunk begins.
-    ///
-    /// For Markdown paragraphs and JSONL this is always `0`.  For elements
-    /// inside a single-line or compactly serialised JSON array it may be
-    /// non-zero.
-    pub column: usize,
+    /// For single-line chunks (JSONL entries, one-line paragraphs), equal to
+    /// `line_start`.
+    pub line_end: usize,
     /// Extracted, human-readable text content (no JSON syntax noise).
     ///
     /// Internal `\n\n` sequences are normalised to `\n` so that the storage
@@ -73,9 +63,7 @@ pub struct TextChunk {
 /// Splits the content of a single file into indexable [`TextChunk`]s.
 ///
 /// Implementations decide the granularity (paragraphs for Markdown, messages
-/// for conversation JSON, …).  The [`line`](TextChunk::line) field of each
-/// chunk must be the 0-based line number of that chunk's start in the original
-/// file.
+/// for conversation JSON, …).
 ///
 /// # Contract
 ///
@@ -83,8 +71,9 @@ pub struct TextChunk {
 /// - Chunks are returned in source order.
 /// - `TextChunk::text` must **not** contain `"\n\n"`; use `"\n"` instead, so
 ///   the storage layer can use `"\n\n"` as the inter-chunk boundary.
-/// - `TextChunk::line` must be unique across all chunks returned for a given
-///   file (stored as the `line` column in the database).
+/// - `TextChunk::line_start` must be unique across all chunks returned for a
+///   given file (stored as the unique key in the database).
+/// - `line_end >= line_start`.
 pub trait Chunker: Send + Sync {
     /// Split `content` (raw file bytes as UTF-8) into chunks.
     ///
@@ -113,14 +102,13 @@ fn count_newlines(s: &str) -> usize {
 
 /// Paragraph-based chunker for Markdown and plain-text files.
 ///
-/// Splits on blank lines (`\n\n`), records the source line of each
-/// paragraph's first non-blank character.
+/// Splits on blank lines (`\n\n`), records the source line range of each
+/// paragraph.
 pub struct MarkdownChunker;
 
 impl Chunker for MarkdownChunker {
     fn chunk(&self, title: &str, content: &str) -> Vec<TextChunk> {
         let mut chunks: Vec<TextChunk> = Vec::new();
-        // Track absolute line number as we consume the content.
         let mut abs_line: usize = 0;
         let mut remaining = content;
 
@@ -129,7 +117,7 @@ impl Chunker for MarkdownChunker {
                 Some(sep_pos) => {
                     let part = &remaining[..sep_pos];
                     push_para_chunk(&mut chunks, part, abs_line);
-                    abs_line += count_newlines(part) + 2; // +2 for the \n\n sep
+                    abs_line += count_newlines(part) + 2;
                     remaining = &remaining[sep_pos + 2..];
                 }
                 None => {
@@ -141,8 +129,8 @@ impl Chunker for MarkdownChunker {
 
         if chunks.is_empty() {
             vec![TextChunk {
-                line: 0,
-                column: 0,
+                line_start: 0,
+                line_end: 0,
                 text: title.to_owned(),
             }]
         } else {
@@ -160,13 +148,13 @@ fn push_para_chunk(chunks: &mut Vec<TextChunk>, part: &str, abs_line: usize) {
     if trimmed.is_empty() {
         return;
     }
-    // Find how many leading newlines the trim() removed so we can compute
-    // the exact line where the non-blank content starts.
     let leading = &part[..part.len() - part.trim_start().len()];
     let leading_newlines = count_newlines(leading);
+    let line_start = abs_line + leading_newlines;
+    let line_end = line_start + count_newlines(trimmed);
     chunks.push(TextChunk {
-        line: abs_line + leading_newlines,
-        column: 0,
+        line_start,
+        line_end,
         text: trimmed.to_owned(),
     });
 }
@@ -178,15 +166,12 @@ fn push_para_chunk(chunks: &mut Vec<TextChunk>, part: &str, abs_line: usize) {
 /// Handles three layouts automatically:
 ///
 /// 1. **JSONL** (one JSON object per line) — each line becomes one chunk.
-///    `line` == the line index in the file.  Suitable for SillyTavern chat
-///    logs (`*.jsonl`) and similar formats.
+///    `line_start == line_end == <line index>`.
 /// 2. **JSON top-level array** — each element becomes one chunk.  The source
-///    `line`/`column` of each element's opening `{` or `[` is tracked by
-///    scanning the raw text.
+///    line range of each element is tracked by scanning the raw text.
 /// 3. **JSON object with a messages/chat field** — extracts the nested array
 ///    (`"messages"`, `"chat"`, `"history"`, or `"log"` key) and treats each
-///    element as a chunk.  `line` is the line of each element's opening `{`.
-///    Falls back to a single chunk for other objects.
+///    element as a chunk.  Falls back to a single chunk for other objects.
 ///
 /// Within each JSON element the chunker extracts human-readable text by
 /// probing common field names:
@@ -205,18 +190,16 @@ pub struct JsonChunker;
 
 impl Chunker for JsonChunker {
     fn chunk(&self, _title: &str, content: &str) -> Vec<TextChunk> {
-        // Try JSONL first: multiple non-empty lines each parseable as JSON.
         if let Some(chunks) = try_parse_jsonl(content) {
             return chunks;
         }
 
-        // Fall back to a single JSON value.
         match serde_json::from_str::<serde_json::Value>(content) {
             Ok(value) => chunks_from_json_value(content, &value),
             Err(_) => {
                 vec![TextChunk {
-                    line: 0,
-                    column: 0,
+                    line_start: 0,
+                    line_end: count_newlines(content),
                     text: normalise(content),
                 }]
             }
@@ -226,10 +209,6 @@ impl Chunker for JsonChunker {
 
 // ── JSONL parsing ─────────────────────────────────────────────────────────────
 
-/// Try to parse `content` as JSONL (newline-delimited JSON).
-///
-/// Returns `None` if the content is not JSONL (e.g. fewer than 2 non-empty
-/// lines, or any non-empty line is not valid JSON).
 fn try_parse_jsonl(content: &str) -> Option<Vec<TextChunk>> {
     let non_empty_lines: Vec<(usize, &str)> = content
         .lines()
@@ -245,11 +224,11 @@ fn try_parse_jsonl(content: &str) -> Option<Vec<TextChunk>> {
     for (line_idx, line_text) in &non_empty_lines {
         match serde_json::from_str::<serde_json::Value>(line_text) {
             Ok(v) => chunks.push(TextChunk {
-                line: *line_idx,
-                column: 0,
+                line_start: *line_idx,
+                line_end: *line_idx,
                 text: extract_message_text(&v),
             }),
-            Err(_) => return None, // not valid JSONL
+            Err(_) => return None,
         }
     }
     Some(chunks)
@@ -257,57 +236,53 @@ fn try_parse_jsonl(content: &str) -> Option<Vec<TextChunk>> {
 
 // ── JSON value → chunks ───────────────────────────────────────────────────────
 
-/// Build chunks from a parsed JSON value, tracking source positions in `raw`.
 fn chunks_from_json_value(raw: &str, value: &serde_json::Value) -> Vec<TextChunk> {
     match value {
         serde_json::Value::Array(arr) => {
-            let positions = find_array_element_positions(raw);
+            let positions = find_array_element_lines(raw);
             arr.iter()
                 .enumerate()
                 .map(|(i, v)| {
-                    let (line, column) = positions.get(i).copied().unwrap_or((i, 0));
+                    let (line_start, line_end) = positions.get(i).copied().unwrap_or((i, i));
                     TextChunk {
-                        line,
-                        column,
+                        line_start,
+                        line_end,
                         text: extract_message_text(v),
                     }
                 })
                 .collect()
         }
         serde_json::Value::Object(map) => {
-            // Look for a nested messages/chat array.
             const ARRAY_KEYS: &[&str] = &["messages", "chat", "history", "log"];
             for key in ARRAY_KEYS {
                 if let Some(serde_json::Value::Array(arr)) = map.get(*key)
                     && !arr.is_empty()
                 {
-                    // Find the position of this key's array in the raw text,
-                    // then scan for element positions within it.
-                    let nested_positions = find_nested_array_positions(raw, key);
+                    let nested_positions = find_nested_array_lines(raw, key);
                     return arr
                         .iter()
                         .enumerate()
                         .map(|(i, v)| {
-                            let (line, column) = nested_positions.get(i).copied().unwrap_or((i, 0));
+                            let (line_start, line_end) =
+                                nested_positions.get(i).copied().unwrap_or((i, i));
                             TextChunk {
-                                line,
-                                column,
+                                line_start,
+                                line_end,
                                 text: extract_message_text(v),
                             }
                         })
                         .collect();
                 }
             }
-            // Single object — one chunk at the start of the file.
             vec![TextChunk {
-                line: 0,
-                column: 0,
+                line_start: 0,
+                line_end: count_newlines(raw),
                 text: extract_message_text(value),
             }]
         }
         other => vec![TextChunk {
-            line: 0,
-            column: 0,
+            line_start: 0,
+            line_end: count_newlines(raw),
             text: normalise(&other.to_string()),
         }],
     }
@@ -315,23 +290,18 @@ fn chunks_from_json_value(raw: &str, value: &serde_json::Value) -> Vec<TextChunk
 
 // ── source-position scanning ──────────────────────────────────────────────────
 
-/// Scan `raw` JSON text for the positions of top-level array elements.
+/// Scan `raw` JSON text for the line range of each top-level array element.
 ///
-/// Returns `(line, column)` for the opening `{`, `[`, `"`, or digit of each
-/// element in the top-level array.
-fn find_array_element_positions(raw: &str) -> Vec<(usize, usize)> {
-    // Find the opening '[' of the top-level array.
+/// Returns `(line_start, line_end)` tuples (inclusive, 0-based).
+fn find_array_element_lines(raw: &str) -> Vec<(usize, usize)> {
     let start = match raw.find('[') {
         Some(i) => i + 1,
         None => return vec![],
     };
-    scan_array_element_positions(raw, start)
+    scan_array_element_lines(raw, start)
 }
 
-/// Same as [`find_array_element_positions`] but first seeks to the value of
-/// `key` inside the top-level object.
-fn find_nested_array_positions(raw: &str, key: &str) -> Vec<(usize, usize)> {
-    // Look for `"key"` followed (after optional whitespace/colon) by `[`.
+fn find_nested_array_lines(raw: &str, key: &str) -> Vec<(usize, usize)> {
     let needle = format!("\"{key}\"");
     let key_pos = match raw.find(&needle) {
         Some(p) => p + needle.len(),
@@ -343,26 +313,28 @@ fn find_nested_array_positions(raw: &str, key: &str) -> Vec<(usize, usize)> {
         None => return vec![],
     };
     let abs_start = key_pos + bracket_offset;
-    scan_array_element_positions(raw, abs_start)
+    scan_array_element_lines(raw, abs_start)
 }
 
-/// Scan `raw[start..]` for the (line, column) of each direct child element of
-/// a JSON array.  `start` is the byte offset just after the opening `[`.
-fn scan_array_element_positions(raw: &str, start: usize) -> Vec<(usize, usize)> {
-    let mut positions: Vec<(usize, usize)> = Vec::new();
+/// Scan `raw[start..]` for the `(line_start, line_end)` of each direct child
+/// element of a JSON array.  `start` is the byte offset just after the opening
+/// `[`.  Both values are inclusive 0-based line numbers.
+fn scan_array_element_lines(raw: &str, start: usize) -> Vec<(usize, usize)> {
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
     let bytes = raw.as_bytes();
     let len = bytes.len();
 
-    // Track line/column up to `start`.
     let prefix = &raw[..start.min(len)];
     let mut line = count_newlines(prefix);
-    let last_nl = prefix.rfind('\n').map(|p| p + 1).unwrap_or(0);
-    let mut col = start.min(len).saturating_sub(last_nl);
 
-    let mut depth: i32 = 0; // depth relative to the array we're scanning
+    let mut depth: i32 = 0;
     let mut in_string = false;
     let mut escaped = false;
     let mut i = start.min(len);
+
+    // Track the currently-open element's start line so we can pair it with
+    // its end when depth returns to 0.
+    let mut current_start: Option<usize> = None;
 
     while i < len {
         let b = bytes[i];
@@ -371,9 +343,6 @@ fn scan_array_element_positions(raw: &str, start: usize) -> Vec<(usize, usize)> 
             escaped = false;
             if b == b'\n' {
                 line += 1;
-                col = 0;
-            } else {
-                col += 1;
             }
             i += 1;
             continue;
@@ -384,12 +353,14 @@ fn scan_array_element_positions(raw: &str, start: usize) -> Vec<(usize, usize)> 
                 escaped = true;
             } else if b == b'"' {
                 in_string = false;
+                if depth == 0 && current_start.is_some() {
+                    // Top-level string element ends at this closing quote.
+                    let s = current_start.take().unwrap();
+                    ranges.push((s, line));
+                }
             }
             if b == b'\n' {
                 line += 1;
-                col = 0;
-            } else {
-                col += 1;
             }
             i += 1;
             continue;
@@ -398,63 +369,68 @@ fn scan_array_element_positions(raw: &str, start: usize) -> Vec<(usize, usize)> 
         match b {
             b'"' => {
                 in_string = true;
-                if depth == 0 {
-                    positions.push((line, col));
+                if depth == 0 && current_start.is_none() {
+                    current_start = Some(line);
                 }
-                col += 1;
             }
             b'{' | b'[' => {
-                if depth == 0 {
-                    positions.push((line, col));
+                if depth == 0 && current_start.is_none() {
+                    current_start = Some(line);
                 }
                 depth += 1;
-                col += 1;
             }
             b'}' | b']' => {
                 depth -= 1;
                 if depth < 0 {
-                    // End of the parent array — stop.
                     break;
                 }
-                col += 1;
+                if depth == 0 && current_start.is_some() {
+                    let s = current_start.take().unwrap();
+                    ranges.push((s, line));
+                }
+            }
+            b',' if depth == 0 => {
+                // Close any pending scalar element at this comma.
+                if let Some(s) = current_start.take() {
+                    ranges.push((s, line));
+                }
+            }
+            b'0'..=b'9' | b'-' | b't' | b'f' | b'n' if depth == 0 => {
+                if current_start.is_none() {
+                    current_start = Some(line);
+                }
             }
             b'\n' => {
                 line += 1;
-                col = 0;
             }
-            b'0'..=b'9' | b'-' | b't' | b'f' | b'n' if depth == 0 => {
-                // Scalar value at top level of array.
-                positions.push((line, col));
-                // Skip until comma or ']'
-                col += 1;
-            }
-            _ => {
-                col += 1;
-            }
+            _ => {}
         }
         i += 1;
     }
 
-    positions
+    // If a scalar is still open when we break (trailing element before `]`),
+    // close it at the current line.
+    if let Some(s) = current_start.take() {
+        ranges.push((s, line));
+    }
+
+    ranges
 }
 
 // ── message text extraction ───────────────────────────────────────────────────
 
-/// Extract a human-readable string from a JSON value representing one message.
 fn extract_message_text(value: &serde_json::Value) -> String {
     let obj = match value.as_object() {
         Some(o) => o,
         None => return normalise(&value.to_string()),
     };
 
-    // Extract the main text content.
     const CONTENT_KEYS: &[&str] = &["mes", "content", "message", "text"];
     let content = CONTENT_KEYS
         .iter()
         .find_map(|k| obj.get(*k)?.as_str())
         .map(str::to_owned);
 
-    // Extract the speaker / role.
     const ROLE_KEYS: &[&str] = &["name", "role", "speaker", "author"];
     let role = ROLE_KEYS
         .iter()
@@ -466,7 +442,6 @@ fn extract_message_text(value: &serde_json::Value) -> String {
         (Some(r), Some(c)) => normalise(&format!("{r}: {c}")),
         (None, Some(c)) => normalise(&c),
         _ => {
-            // Fall back: join all string-valued fields.
             let fallback = obj
                 .iter()
                 .filter_map(|(k, v)| v.as_str().map(|s| format!("{k}: {s}")))
@@ -488,22 +463,6 @@ fn extract_message_text(value: &serde_json::Value) -> String {
 /// This function is used internally by the SQLite and LanceDB storage backends
 /// as the default chunking strategy when no pre-computed chunks are provided.
 /// New code should prefer the [`Chunker`] trait.
-///
-/// Splitting rules:
-///
-/// 1. The body is split on blank lines (`\n\n`).
-/// 2. The title is prepended to every chunk.
-/// 3. If the body is empty, a single title-only chunk is returned.
-///
-/// # Example
-///
-/// ```
-/// # use sapphire_retrieve::chunker::chunk_document;
-/// let chunks = chunk_document("Meeting notes", "First item.\n\nSecond item.");
-/// assert_eq!(chunks.len(), 2);
-/// assert_eq!(chunks[0], "Meeting notes\n\nFirst item.");
-/// assert_eq!(chunks[1], "Meeting notes\n\nSecond item.");
-/// ```
 pub fn chunk_document(title: &str, body: &str) -> Vec<String> {
     let paragraphs: Vec<&str> = body
         .split("\n\n")
@@ -531,8 +490,6 @@ pub fn chunk_document(title: &str, body: &str) -> Vec<String> {
 mod tests {
     use super::*;
 
-    // ── chunk_document (legacy) ──────────────────────────────────────────────
-
     #[test]
     fn two_paragraphs() {
         let chunks = chunk_document("Title", "First.\n\nSecond.");
@@ -554,12 +511,6 @@ mod tests {
     }
 
     #[test]
-    fn filters_empty_paragraphs() {
-        let chunks = chunk_document("T", "Para 1.\n\n\n\nPara 2.");
-        assert_eq!(chunks.len(), 2);
-    }
-
-    #[test]
     fn empty_title() {
         let chunks = chunk_document("", "Only body.");
         assert_eq!(chunks, vec!["Only body."]);
@@ -568,50 +519,54 @@ mod tests {
     // ── MarkdownChunker ──────────────────────────────────────────────────────
 
     #[test]
-    fn markdown_line_numbers() {
+    fn markdown_line_range_single_line() {
         let c = MarkdownChunker;
-        // Line 0: "First."
-        // Line 1: ""   (blank)
-        // Line 2: "Second."
         let chunks = c.chunk("Title", "First.\n\nSecond.");
         assert_eq!(chunks.len(), 2);
-        assert_eq!(chunks[0].line, 0);
+        assert_eq!(chunks[0].line_start, 0);
+        assert_eq!(chunks[0].line_end, 0);
         assert_eq!(chunks[0].text, "First.");
-        assert_eq!(chunks[1].line, 2);
+        assert_eq!(chunks[1].line_start, 2);
+        assert_eq!(chunks[1].line_end, 2);
         assert_eq!(chunks[1].text, "Second.");
+    }
+
+    #[test]
+    fn markdown_multiline_paragraph() {
+        let c = MarkdownChunker;
+        // "A\nB\nC" is a single paragraph spanning lines 0-2.
+        let chunks = c.chunk("T", "A\nB\nC\n\nD");
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].line_start, 0);
+        assert_eq!(chunks[0].line_end, 2);
+        assert_eq!(chunks[0].text, "A\nB\nC");
+        assert_eq!(chunks[1].line_start, 4);
+        assert_eq!(chunks[1].line_end, 4);
     }
 
     #[test]
     fn markdown_leading_blank_lines() {
         let c = MarkdownChunker;
-        // Content starts with two blank lines before the paragraph.
         let chunks = c.chunk("T", "\n\nActual paragraph.");
         assert_eq!(chunks.len(), 1);
-        assert_eq!(chunks[0].line, 2);
+        assert_eq!(chunks[0].line_start, 2);
+        assert_eq!(chunks[0].line_end, 2);
     }
 
     #[test]
-    fn markdown_empty_body_returns_title_at_line_0() {
+    fn markdown_empty_body_returns_title() {
         let c = MarkdownChunker;
         let chunks = c.chunk("Title", "");
         assert_eq!(chunks.len(), 1);
-        assert_eq!(chunks[0].line, 0);
+        assert_eq!(chunks[0].line_start, 0);
+        assert_eq!(chunks[0].line_end, 0);
         assert_eq!(chunks[0].text, "Title");
-    }
-
-    #[test]
-    fn markdown_column_always_zero() {
-        let c = MarkdownChunker;
-        let chunks = c.chunk("T", "A.\n\nB.\n\nC.");
-        for ch in &chunks {
-            assert_eq!(ch.column, 0, "expected column 0 for markdown chunk");
-        }
     }
 
     // ── JsonChunker ──────────────────────────────────────────────────────────
 
     #[test]
-    fn jsonl_line_numbers() {
+    fn jsonl_line_ranges() {
         let c = JsonChunker;
         let jsonl = concat!(
             "{\"name\":\"User\",\"is_user\":true,\"mes\":\"Hello there\"}\n",
@@ -619,29 +574,12 @@ mod tests {
         );
         let chunks = c.chunk("chat.jsonl", jsonl);
         assert_eq!(chunks.len(), 2);
-        assert_eq!(chunks[0].line, 0, "first message should be on line 0");
-        assert_eq!(chunks[1].line, 1, "second message should be on line 1");
-        assert!(
-            chunks[0].text.contains("Hello there"),
-            "got: {}",
-            chunks[0].text
-        );
-        assert!(
-            chunks[1].text.contains("Hi! How can I help?"),
-            "got: {}",
-            chunks[1].text
-        );
-    }
-
-    #[test]
-    fn jsonl_column_always_zero() {
-        let c = JsonChunker;
-        let jsonl =
-            "{\"role\":\"user\",\"content\":\"A\"}\n{\"role\":\"assistant\",\"content\":\"B\"}";
-        let chunks = c.chunk("chat.jsonl", jsonl);
-        for ch in &chunks {
-            assert_eq!(ch.column, 0, "JSONL chunks should always have column 0");
-        }
+        assert_eq!(chunks[0].line_start, 0);
+        assert_eq!(chunks[0].line_end, 0);
+        assert_eq!(chunks[1].line_start, 1);
+        assert_eq!(chunks[1].line_end, 1);
+        assert!(chunks[0].text.contains("Hello there"));
+        assert!(chunks[1].text.contains("Hi! How can I help?"));
     }
 
     #[test]
@@ -650,14 +588,11 @@ mod tests {
         let json = "{\n  \"messages\": [\n    {\"role\":\"user\",\"content\":\"What is 2+2?\"},\n    {\"role\":\"assistant\",\"content\":\"4\"}\n  ]\n}";
         let chunks = c.chunk("session.json", json);
         assert_eq!(chunks.len(), 2);
-        assert!(chunks[0].text.contains("2+2"), "got: {}", chunks[0].text);
-        assert!(chunks[1].text.contains('4'), "got: {}", chunks[1].text);
-        // Messages start at lines 2 and 3 in the pretty-printed JSON above.
-        assert!(
-            chunks[0].line >= 2,
-            "expected line >= 2, got {}",
-            chunks[0].line
-        );
+        // Both message objects are single-line in this layout.
+        assert_eq!(chunks[0].line_start, chunks[0].line_end);
+        assert_eq!(chunks[1].line_start, chunks[1].line_end);
+        assert!(chunks[0].line_start >= 2);
+        assert!(chunks[1].line_start > chunks[0].line_start);
     }
 
     #[test]
@@ -666,9 +601,26 @@ mod tests {
         let json = "[\n  {\"role\":\"user\",\"content\":\"Ping\"},\n  {\"role\":\"assistant\",\"content\":\"Pong\"}\n]";
         let chunks = c.chunk("msgs.json", json);
         assert_eq!(chunks.len(), 2);
-        assert!(chunks[0].text.contains("Ping"), "got: {}", chunks[0].text);
-        assert!(chunks[1].text.contains("Pong"), "got: {}", chunks[1].text);
-        assert!(chunks[0].line >= 1, "first element starts on line 1");
+        assert!(chunks[0].text.contains("Ping"));
+        assert!(chunks[1].text.contains("Pong"));
+        assert!(chunks[0].line_start >= 1);
+        assert_eq!(chunks[0].line_start, chunks[0].line_end);
+    }
+
+    #[test]
+    fn json_array_multiline_element() {
+        let c = JsonChunker;
+        // A single pretty-printed element spanning multiple lines.
+        let json = "[\n  {\n    \"role\": \"user\",\n    \"content\": \"Hello\"\n  }\n]";
+        let chunks = c.chunk("msgs.json", json);
+        assert_eq!(chunks.len(), 1);
+        assert!(chunks[0].line_start >= 1);
+        assert!(
+            chunks[0].line_end > chunks[0].line_start,
+            "expected multi-line range, got {}..={}",
+            chunks[0].line_start,
+            chunks[0].line_end
+        );
     }
 
     #[test]
@@ -677,12 +629,9 @@ mod tests {
         let json = "{\"role\":\"user\",\"content\":\"Just one message\"}";
         let chunks = c.chunk("single.json", json);
         assert_eq!(chunks.len(), 1);
-        assert_eq!(chunks[0].line, 0);
-        assert!(
-            chunks[0].text.contains("Just one message"),
-            "got: {}",
-            chunks[0].text
-        );
+        assert_eq!(chunks[0].line_start, 0);
+        assert_eq!(chunks[0].line_end, 0);
+        assert!(chunks[0].text.contains("Just one message"));
     }
 
     #[test]
@@ -694,12 +643,7 @@ mod tests {
         );
         let chunks = c.chunk("chat.jsonl", jsonl);
         for ch in &chunks {
-            assert!(
-                !ch.text.contains("\n\n"),
-                "chunk at line {} contains \\n\\n: {:?}",
-                ch.line,
-                ch.text
-            );
+            assert!(!ch.text.contains("\n\n"));
         }
     }
 }

--- a/crates/sapphire-retrieve/src/db.rs
+++ b/crates/sapphire-retrieve/src/db.rs
@@ -32,7 +32,7 @@ use std::{
 use crate::{
     embed::Embedder,
     error::Result,
-    retrieve_store::RetrieveStore,
+    retrieve_store::{FtsQuery, HybridQuery, RetrieveStore, VectorQuery},
     vector_store::{ChunkSearchResult, VecInfo},
 };
 
@@ -115,16 +115,23 @@ impl RetrieveStore for InMemoryStore {
         Ok(())
     }
 
-    fn search_fts(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
+    fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<SearchResult>> {
         let state = self.state.lock().unwrap();
-        let q = query.to_lowercase();
+        let needle = q.query.to_lowercase();
+        let prefix = q.path_prefix.map(|p| p.to_string_lossy().to_string());
         let mut results: Vec<SearchResult> = state
             .documents
             .values()
             .filter(|doc| {
-                doc.title.to_lowercase().contains(&q) || doc.body.to_lowercase().contains(&q)
+                if let Some(ref pfx) = prefix {
+                    if !doc.path.starts_with(pfx.as_str()) {
+                        return false;
+                    }
+                }
+                doc.title.to_lowercase().contains(&needle)
+                    || doc.body.to_lowercase().contains(&needle)
             })
-            .take(limit)
+            .take(q.limit)
             .map(|doc| SearchResult {
                 id: doc.id,
                 title: doc.title.clone(),
@@ -167,7 +174,7 @@ impl RetrieveStore for InMemoryStore {
         })
     }
 
-    fn search_similar(&self, _query_vec: &[f32], _limit: usize) -> Result<Vec<ChunkSearchResult>> {
+    fn search_similar(&self, _q: &VectorQuery<'_>) -> Result<Vec<ChunkSearchResult>> {
         Ok(vec![])
     }
 }
@@ -334,19 +341,20 @@ impl RetrieveDb {
     /// SQLite mode uses the FTS5 trigram index (substring / CJK aware).
     /// LanceDB mode uses the ngram tokenizer (better BM25 ranking).
     /// In-memory mode uses a simple case-insensitive substring scan.
-    pub fn search_fts(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
-        self.store().search_fts(query, limit)
+    pub fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<SearchResult>> {
+        self.store().search_fts(q)
     }
 
     /// Find the `limit` most similar chunks to `query_vec`.
     ///
     /// Returns an empty `Vec` when no vector backend is configured.
-    pub fn search_similar(
-        &self,
-        query_vec: &[f32],
-        limit: usize,
-    ) -> Result<Vec<ChunkSearchResult>> {
-        self.store().search_similar(query_vec, limit)
+    pub fn search_similar(&self, q: &VectorQuery<'_>) -> Result<Vec<ChunkSearchResult>> {
+        self.store().search_similar(q)
+    }
+
+    /// Hybrid search combining FTS and vector similarity via RRF.
+    pub fn search_hybrid(&self, q: &HybridQuery<'_>) -> Result<Vec<SearchResult>> {
+        self.store().search_hybrid(q)
     }
 
     /// Deduplicate chunk search results to one `SearchResult` per document.
@@ -455,6 +463,74 @@ pub fn dedup_chunk_results(results: Vec<ChunkSearchResult>, limit: usize) -> Vec
             score: r.score,
         })
         .collect()
+}
+
+/// Merge two ranked result lists via Reciprocal Rank Fusion.
+///
+/// `score(d) = w_fts / (k + rank_fts) + w_sem / (k + rank_sem)`
+///
+/// Documents appearing in only one list receive a contribution from that
+/// list alone.  The returned list is sorted by descending RRF score.
+pub fn merge_rrf(
+    fts: &[SearchResult],
+    sem: &[SearchResult],
+    k: f64,
+    w_fts: f64,
+    w_sem: f64,
+    limit: usize,
+) -> Vec<SearchResult> {
+    let mut scores: HashMap<String, (SearchResult, f64)> = HashMap::new();
+
+    for (rank, result) in fts.iter().enumerate() {
+        let rrf = w_fts / (k + (rank + 1) as f64);
+        scores
+            .entry(result.path.clone())
+            .and_modify(|(_, s)| *s += rrf)
+            .or_insert_with(|| (result.clone(), rrf));
+    }
+
+    for (rank, result) in sem.iter().enumerate() {
+        let rrf = w_sem / (k + (rank + 1) as f64);
+        scores
+            .entry(result.path.clone())
+            .and_modify(|(_, s)| *s += rrf)
+            .or_insert_with(|| (result.clone(), rrf));
+    }
+
+    let mut merged: Vec<_> = scores.into_values().collect();
+    merged.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    merged.truncate(limit);
+
+    merged
+        .into_iter()
+        .map(|(mut result, rrf_score)| {
+            result.score = rrf_score;
+            result
+        })
+        .collect()
+}
+
+/// Default hybrid search implementation used by [`RetrieveStore::search_hybrid`].
+///
+/// Calls `search_fts` + `search_similar` on the given store, deduplicates
+/// chunks, and merges via [`merge_rrf`].
+pub fn default_hybrid<S: RetrieveStore + ?Sized>(
+    store: &S,
+    q: &HybridQuery<'_>,
+) -> Result<Vec<SearchResult>> {
+    let over_fetch = q.limit * 3;
+    let fts = store.search_fts(&FtsQuery {
+        query: q.text,
+        limit: over_fetch,
+        path_prefix: q.path_prefix,
+    })?;
+    let raw = store.search_similar(&VectorQuery {
+        query_vec: q.query_vec,
+        limit: over_fetch,
+        path_prefix: q.path_prefix,
+    })?;
+    let sem = dedup_chunk_results(raw, over_fetch);
+    Ok(merge_rrf(&fts, &sem, q.rrf_k, q.weight_fts, q.weight_sem, q.limit))
 }
 
 // ── backend factory functions ─────────────────────────────────────────────────

--- a/crates/sapphire-retrieve/src/db.rs
+++ b/crates/sapphire-retrieve/src/db.rs
@@ -3,25 +3,6 @@
 //! [`RetrieveDb`] is the main entry point.  It manages one of the available
 //! storage backends and exposes a unified API for file tracking, document
 //! management, full-text search, and vector search.
-//!
-//! # Choosing a backend
-//!
-//! Call one of the `init_*` methods after [`RetrieveDb::open`]:
-//!
-//! | Method | Backend | Notes |
-//! |--------|---------|-------|
-//! | *(none)* | SQLite FTS only | Default when `sqlite-store` is enabled |
-//! | [`init_sqlite_vec`](Self::init_sqlite_vec) | SQLite + sqlite-vec | Lightweight; requires `sqlite-store` |
-//! | [`init_lancedb`](Self::init_lancedb) | LanceDB (full) | Requires `lancedb-store` feature; no SQLite file |
-//!
-//! When neither `sqlite-store` nor `lancedb-store` is compiled in, an
-//! in-memory backend is used: documents are stored in a `HashMap` and
-//! a simple substring search is available.  Data is not persisted to disk.
-//!
-//! # Thread safety
-//!
-//! [`RetrieveDb`] is `Send + Sync`.  Each public method briefly acquires an
-//! internal lock to clone the `Arc`-wrapped backend, then operates independently.
 
 use std::{
     collections::HashMap,
@@ -32,11 +13,11 @@ use std::{
 use crate::{
     embed::Embedder,
     error::Result,
-    retrieve_store::{FtsQuery, HybridQuery, RetrieveStore, VectorQuery},
-    vector_store::{ChunkSearchResult, VecInfo},
+    retrieve_store::{
+        ChunkHit, Document, FileSearchResult, FtsQuery, HybridQuery, RetrieveStore, VectorQuery,
+    },
+    vector_store::VecInfo,
 };
-
-pub use crate::retrieve_store::{Document, SearchResult};
 
 #[cfg(feature = "sqlite-store")]
 use crate::sqlite_store::SqliteStore;
@@ -44,7 +25,6 @@ use crate::sqlite_store::SqliteStore;
 #[cfg(feature = "lancedb-store")]
 use crate::lancedb_store::LanceDbBackend;
 
-// Re-export the SQLite schema version (used by workspace helpers and the CLI).
 #[cfg(feature = "sqlite-store")]
 pub use crate::sqlite_store::SCHEMA_VERSION;
 
@@ -52,10 +32,7 @@ pub use crate::sqlite_store::SCHEMA_VERSION;
 
 /// In-memory backend used when no persistent storage feature is compiled in.
 ///
-/// All data lives in `HashMap`s and is lost when the process exits.
-/// FTS is implemented as a simple case-insensitive substring scan.
-/// This backend is also the *initial* state when the [`lancedb-store`] feature
-/// is enabled but [`RetrieveDb::init_lancedb`] has not yet been called.
+/// Data lives in `HashMap`s and is lost when the process exits.
 struct InMemoryStore {
     state: Mutex<InMemoryState>,
 }
@@ -115,11 +92,11 @@ impl RetrieveStore for InMemoryStore {
         Ok(())
     }
 
-    fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<SearchResult>> {
+    fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<FileSearchResult>> {
         let state = self.state.lock().unwrap();
         let needle = q.query.to_lowercase();
         let prefix = q.path_prefix.map(|p| p.to_string_lossy().to_string());
-        let mut results: Vec<SearchResult> = state
+        let mut results: Vec<FileSearchResult> = state
             .documents
             .values()
             .filter(|doc| {
@@ -132,11 +109,17 @@ impl RetrieveStore for InMemoryStore {
                     || doc.body.to_lowercase().contains(&needle)
             })
             .take(q.limit)
-            .map(|doc| SearchResult {
+            .map(|doc| FileSearchResult {
                 id: doc.id,
                 title: doc.title.clone(),
                 path: doc.path.clone(),
                 score: 0.0,
+                chunks: vec![ChunkHit {
+                    line_start: 0,
+                    line_end: 0,
+                    text: doc.title.clone(),
+                    score: 0.0,
+                }],
             })
             .collect();
         results.sort_by(|a, b| a.title.cmp(&b.title));
@@ -174,7 +157,7 @@ impl RetrieveStore for InMemoryStore {
         })
     }
 
-    fn search_similar(&self, _q: &VectorQuery<'_>) -> Result<Vec<ChunkSearchResult>> {
+    fn search_similar(&self, _q: &VectorQuery<'_>) -> Result<Vec<FileSearchResult>> {
         Ok(vec![])
     }
 }
@@ -182,22 +165,15 @@ impl RetrieveStore for InMemoryStore {
 // ── backend state ─────────────────────────────────────────────────────────────
 
 enum BackendState {
-    /// In-memory backend — data is not persisted.
-    ///
-    /// Used when neither `sqlite-store` nor `lancedb-store` is compiled in,
-    /// and as the initial state before [`RetrieveDb::init_lancedb`] is called.
     #[allow(dead_code)]
     InMemory(Arc<InMemoryStore>),
-    /// SQLite backend (FTS only or FTS + sqlite-vec).
     #[cfg(feature = "sqlite-store")]
     Sqlite(Arc<SqliteStore>),
-    /// Full LanceDB backend.
     #[cfg(feature = "lancedb-store")]
     LanceDb(Arc<LanceDbBackend>),
 }
 
 impl BackendState {
-    /// Return the underlying [`RetrieveStore`] as a cloned `Arc`.
     fn as_store(&self) -> Arc<dyn RetrieveStore> {
         match self {
             BackendState::InMemory(s) => Arc::clone(s) as Arc<dyn RetrieveStore>,
@@ -208,7 +184,6 @@ impl BackendState {
         }
     }
 
-    /// Returns `true` when the backend should be replaced by an `init_*` call.
     fn needs_init(&self) -> bool {
         match self {
             BackendState::InMemory(_) => true,
@@ -222,30 +197,12 @@ impl BackendState {
 
 // ── RetrieveDb ────────────────────────────────────────────────────────────────
 
-/// Manages the retrieve backend for full-text and (optionally) vector search.
-///
-/// Create with [`RetrieveDb::open`], then call:
-/// - [`upsert_document`](Self::upsert_document) / [`remove_document`](Self::remove_document) to keep the index in sync.
-/// - [`rebuild_fts`](Self::rebuild_fts) after a batch of upserts/removes.
-/// - [`search_fts`](Self::search_fts) for full-text search.
-/// - Optionally call [`init_sqlite_vec`](Self::init_sqlite_vec) or
-///   [`init_lancedb`](Self::init_lancedb), then use
-///   [`embed_pending`](Self::embed_pending) and
-///   [`search_similar`](Self::search_similar) for vector search.
 pub struct RetrieveDb {
     db_path: PathBuf,
     backend: Mutex<BackendState>,
 }
 
 impl RetrieveDb {
-    /// Open the retrieve database at `db_path`.
-    ///
-    /// When `sqlite-store` is enabled, defaults to the SQLite FTS-only backend
-    /// (the SQLite file is created lazily on first use).  When no storage
-    /// feature is compiled in, opens an in-memory backend.
-    ///
-    /// Call [`init_sqlite_vec`](Self::init_sqlite_vec) or
-    /// [`init_lancedb`](Self::init_lancedb) to enable vector search.
     pub fn open(db_path: &Path) -> Result<Self> {
         #[cfg(feature = "sqlite-store")]
         {
@@ -263,18 +220,12 @@ impl RetrieveDb {
         })
     }
 
-    /// Delete the existing database and create a fresh one.
     pub fn rebuild(db_path: &Path) -> Result<Self> {
         #[cfg(feature = "sqlite-store")]
         crate::sqlite_store::wipe_db_files(db_path);
         Self::open(db_path)
     }
 
-    // ── vector backend init ───────────────────────────────────────────────────
-
-    /// Enable the sqlite-vec vector backend with `embedding_dim` dimensions.
-    ///
-    /// Idempotent — if the backend is already initialised this is a no-op.
     #[cfg(feature = "sqlite-store")]
     pub fn init_sqlite_vec(&self, embedding_dim: u32) -> Result<()> {
         let mut guard = self.backend.lock().unwrap();
@@ -285,10 +236,6 @@ impl RetrieveDb {
         Ok(())
     }
 
-    /// Enable the LanceDB full backend (files + documents + chunks + vectors).
-    ///
-    /// When active, all data lives in LanceDB tables under `lancedb_dir`.
-    /// No SQLite file is created.  Idempotent.
     #[cfg(feature = "lancedb-store")]
     pub fn init_lancedb(&self, lancedb_dir: &Path, embedding_dim: u32) -> Result<()> {
         let mut guard = self.backend.lock().unwrap();
@@ -299,89 +246,40 @@ impl RetrieveDb {
         Ok(())
     }
 
-    // ── helpers ───────────────────────────────────────────────────────────────
-
-    /// Clone the active backend as an `Arc<dyn RetrieveStore>`.
-    ///
-    /// The lock is released immediately after cloning the `Arc`, so long-running
-    /// operations do not block other threads from checking the backend state.
     fn store(&self) -> Arc<dyn RetrieveStore> {
         self.backend.lock().unwrap().as_store()
     }
 
     // ── document management ───────────────────────────────────────────────────
 
-    /// Insert or replace a document in the retrieve database.
-    ///
-    /// Also re-chunks the document body and updates the chunks table.
-    /// Stale embeddings for changed chunks are removed automatically.
-    ///
-    /// Call [`rebuild_fts`](Self::rebuild_fts) after a batch of upserts.
     pub fn upsert_document(&self, doc: &Document) -> Result<()> {
         self.store().upsert_document(doc)
     }
 
-    /// Remove a document (and its chunks / embeddings) from the database.
     pub fn remove_document(&self, id: i64) -> Result<()> {
         self.store().remove_document(id)
     }
 
-    /// Rebuild the FTS index from the current `documents` table.
-    ///
-    /// Call this after a batch of [`upsert_document`](Self::upsert_document)
-    /// calls or whenever the FTS index may be out of date.
     pub fn rebuild_fts(&self) -> Result<()> {
         self.store().rebuild_fts()
     }
 
     // ── search ────────────────────────────────────────────────────────────────
 
-    /// Full-text search.
-    ///
-    /// SQLite mode uses the FTS5 trigram index (substring / CJK aware).
-    /// LanceDB mode uses the ngram tokenizer (better BM25 ranking).
-    /// In-memory mode uses a simple case-insensitive substring scan.
-    pub fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<SearchResult>> {
+    pub fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<FileSearchResult>> {
         self.store().search_fts(q)
     }
 
-    /// Find the `limit` most similar chunks to `query_vec`.
-    ///
-    /// Returns an empty `Vec` when no vector backend is configured.
-    pub fn search_similar(&self, q: &VectorQuery<'_>) -> Result<Vec<ChunkSearchResult>> {
+    pub fn search_similar(&self, q: &VectorQuery<'_>) -> Result<Vec<FileSearchResult>> {
         self.store().search_similar(q)
     }
 
-    /// Hybrid search combining FTS and vector similarity via RRF.
-    pub fn search_hybrid(&self, q: &HybridQuery<'_>) -> Result<Vec<SearchResult>> {
+    pub fn search_hybrid(&self, q: &HybridQuery<'_>) -> Result<Vec<FileSearchResult>> {
         self.store().search_hybrid(q)
-    }
-
-    /// Deduplicate chunk search results to one `SearchResult` per document.
-    ///
-    /// When multiple chunks from the same document match, only the best-scoring
-    /// (lowest L2 distance) chunk is kept.  Returns up to `limit` results
-    /// ordered by ascending score.
-    ///
-    /// # Deprecation
-    ///
-    /// Prefer the free function [`dedup_chunk_results`] instead.
-    #[deprecated(
-        since = "0.7.0",
-        note = "use the free function `dedup_chunk_results` instead"
-    )]
-    pub fn dedup_chunk_results(results: Vec<ChunkSearchResult>, limit: usize) -> Vec<SearchResult> {
-        dedup_chunk_results(results, limit)
     }
 
     // ── embedding ─────────────────────────────────────────────────────────────
 
-    /// Generate and store embeddings for all pending (unembedded) chunks.
-    ///
-    /// Returns the number of newly embedded chunks.  Returns 0 immediately
-    /// when no vector backend is configured.
-    ///
-    /// `on_progress(done, total)` is called after each batch of 100 chunks.
     pub fn embed_pending(
         &self,
         embedder: &dyn Embedder,
@@ -390,39 +288,32 @@ impl RetrieveDb {
         self.store().embed_pending(embedder, &on_progress)
     }
 
-    /// Read vector index statistics.
     pub fn vec_info(&self) -> Result<VecInfo> {
         self.store().vec_info()
     }
 
-    /// Return the IDs of all documents in the database.
     pub fn document_ids(&self) -> Result<Vec<i64>> {
         self.store().document_ids()
     }
 
-    /// Return the total number of documents in the database.
     pub fn document_count(&self) -> Result<u64> {
         self.store().document_count()
     }
 
     // ── file tracking ─────────────────────────────────────────────────────────
 
-    /// Return all tracked (path, file_mtime) pairs.
     pub fn file_mtimes(&self) -> Result<HashMap<String, i64>> {
         self.store().file_mtimes()
     }
 
-    /// Insert or replace a file record.
     pub fn upsert_file(&self, path: &str, mtime: i64) -> Result<()> {
         self.store().upsert_file(path, mtime)
     }
 
-    /// Delete a file record.
     pub fn remove_file(&self, path: &str) -> Result<()> {
         self.store().remove_file(path)
     }
 
-    /// Return the total number of tracked files.
     pub fn file_count(&self) -> Result<u64> {
         self.store().file_count()
     }
@@ -430,129 +321,117 @@ impl RetrieveDb {
 
 // ── free functions ────────────────────────────────────────────────────────────
 
-/// Deduplicate chunk search results to one [`SearchResult`] per document.
+/// Merge FTS and semantic file-level results via Reciprocal Rank Fusion.
 ///
-/// When multiple chunks from the same document match, only the best-scoring
-/// (lowest L2 distance) chunk is kept.  Returns up to `limit` results
-/// ordered by ascending score.
-pub fn dedup_chunk_results(results: Vec<ChunkSearchResult>, limit: usize) -> Vec<SearchResult> {
-    let mut best: HashMap<i64, ChunkSearchResult> = HashMap::new();
-    for r in results {
-        best.entry(r.doc_id)
-            .and_modify(|e| {
-                if r.score < e.score {
-                    *e = r.clone();
-                }
-            })
-            .or_insert(r);
-    }
-
-    let mut deduped: Vec<_> = best.into_values().collect();
-    deduped.sort_by(|a, b| {
-        a.score
-            .partial_cmp(&b.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-    deduped.truncate(limit);
-    deduped
-        .into_iter()
-        .map(|r| SearchResult {
-            id: r.doc_id,
-            title: r.doc_title,
-            path: r.doc_path,
-            score: r.score,
-        })
-        .collect()
-}
-
-/// Merge two ranked result lists via Reciprocal Rank Fusion.
-///
-/// `score(d) = w_fts / (k + rank_fts) + w_sem / (k + rank_sem)`
-///
-/// Documents appearing in only one list receive a contribution from that
-/// list alone.  The returned list is sorted by descending RRF score.
-pub fn merge_rrf(
-    fts: &[SearchResult],
-    sem: &[SearchResult],
+/// `score(d) = w_fts / (k + rank_fts) + w_sem / (k + rank_sem)`.  Chunks from
+/// both inputs are merged (deduplicated by `(line_start, line_end)`, keeping
+/// the best per-chunk score).  Output is sorted by descending RRF score.
+pub fn merge_rrf_files(
+    fts: &[FileSearchResult],
+    sem: &[FileSearchResult],
     k: f64,
     w_fts: f64,
     w_sem: f64,
     limit: usize,
-) -> Vec<SearchResult> {
-    let mut scores: HashMap<String, (SearchResult, f64)> = HashMap::new();
+) -> Vec<FileSearchResult> {
+    // Index FTS results by path (stable id alternative would work too).
+    let mut acc: HashMap<String, (FileSearchResult, f64)> = HashMap::new();
 
-    for (rank, result) in fts.iter().enumerate() {
+    for (rank, file) in fts.iter().enumerate() {
         let rrf = w_fts / (k + (rank + 1) as f64);
-        scores
-            .entry(result.path.clone())
-            .and_modify(|(_, s)| *s += rrf)
-            .or_insert_with(|| (result.clone(), rrf));
+        acc.insert(file.path.clone(), (file.clone(), rrf));
     }
 
-    for (rank, result) in sem.iter().enumerate() {
+    for (rank, file) in sem.iter().enumerate() {
         let rrf = w_sem / (k + (rank + 1) as f64);
-        scores
-            .entry(result.path.clone())
-            .and_modify(|(_, s)| *s += rrf)
-            .or_insert_with(|| (result.clone(), rrf));
+        acc.entry(file.path.clone())
+            .and_modify(|(existing, s)| {
+                *s += rrf;
+                merge_chunk_hits(&mut existing.chunks, &file.chunks);
+            })
+            .or_insert_with(|| (file.clone(), rrf));
     }
 
-    let mut merged: Vec<_> = scores.into_values().collect();
+    let mut merged: Vec<_> = acc.into_values().collect();
     merged.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     merged.truncate(limit);
 
     merged
         .into_iter()
-        .map(|(mut result, rrf_score)| {
-            result.score = rrf_score;
-            result
+        .map(|(mut file, rrf_score)| {
+            file.score = rrf_score;
+            file
         })
         .collect()
 }
 
+/// Merge `incoming` into `existing`, deduplicating by `(line_start, line_end)`.
+///
+/// When a chunk exists in both lists, the one from `existing` is kept (so FTS
+/// scores win over vector scores on the same chunk, which matches the order
+/// `merge_rrf_files` calls this).
+fn merge_chunk_hits(existing: &mut Vec<ChunkHit>, incoming: &[ChunkHit]) {
+    use std::collections::HashSet;
+    let seen: HashSet<(usize, usize)> = existing
+        .iter()
+        .map(|c| (c.line_start, c.line_end))
+        .collect();
+    for c in incoming {
+        if !seen.contains(&(c.line_start, c.line_end)) {
+            existing.push(c.clone());
+        }
+    }
+}
+
 /// Default hybrid search implementation used by [`RetrieveStore::search_hybrid`].
 ///
-/// Calls `search_fts` + `search_similar` on the given store, deduplicates
-/// chunks, and merges via [`merge_rrf`].
+/// Calls `search_fts` and, when an embedder is provided, `search_similar`;
+/// then merges results via [`merge_rrf_files`].  When `q.embedder` is `None`,
+/// falls back to FTS-only output.
 pub fn default_hybrid<S: RetrieveStore + ?Sized>(
     store: &S,
     q: &HybridQuery<'_>,
-) -> Result<Vec<SearchResult>> {
+) -> Result<Vec<FileSearchResult>> {
     let over_fetch = q.limit * 3;
     let fts = store.search_fts(&FtsQuery {
-        query: q.text,
+        query: q.query,
         limit: over_fetch,
         path_prefix: q.path_prefix,
     })?;
-    let raw = store.search_similar(&VectorQuery {
-        query_vec: q.query_vec,
+
+    let Some(embedder) = q.embedder else {
+        return Ok(fts.into_iter().take(q.limit).collect());
+    };
+
+    let sem = store.search_similar(&VectorQuery {
+        query: q.query,
+        embedder,
         limit: over_fetch,
         path_prefix: q.path_prefix,
     })?;
-    let sem = dedup_chunk_results(raw, over_fetch);
-    Ok(merge_rrf(&fts, &sem, q.rrf_k, q.weight_fts, q.weight_sem, q.limit))
+
+    Ok(merge_rrf_files(
+        &fts,
+        &sem,
+        q.rrf_k,
+        q.weight_fts,
+        q.weight_sem,
+        q.limit,
+    ))
 }
 
 // ── backend factory functions ─────────────────────────────────────────────────
 
 /// Open or create an in-memory backend.
-///
-/// Data is not persisted to disk — all state is lost when the process exits.
-/// Use as a fallback when no storage feature is compiled in, or in tests.
 pub fn open_in_memory() -> Arc<dyn RetrieveStore + Send + Sync> {
     Arc::new(InMemoryStore::new())
 }
 
-/// Open or create a SQLite FTS-only backend at `db_path`.
-///
-/// The SQLite file is created lazily on first use.
-/// Call [`open_sqlite_vec`] instead to enable vector search.
 #[cfg(feature = "sqlite-store")]
 pub fn open_sqlite_fts(db_path: &Path) -> Arc<dyn RetrieveStore + Send + Sync> {
     Arc::new(SqliteStore::new_fts_only(db_path.to_owned()))
 }
 
-/// Open or create a SQLite + sqlite-vec backend at `db_path` with `dim`-dimensional embeddings.
 #[cfg(feature = "sqlite-store")]
 pub fn open_sqlite_vec(db_path: &Path, dim: u32) -> Result<Arc<dyn RetrieveStore + Send + Sync>> {
     Ok(Arc::new(SqliteStore::new_with_vec(
@@ -561,7 +440,6 @@ pub fn open_sqlite_vec(db_path: &Path, dim: u32) -> Result<Arc<dyn RetrieveStore
     )?))
 }
 
-/// Open or create a LanceDB backend under `data_dir` with `dim`-dimensional embeddings.
 #[cfg(feature = "lancedb-store")]
 pub fn open_lancedb(data_dir: &Path, dim: u32) -> Result<Arc<dyn RetrieveStore + Send + Sync>> {
     Ok(Arc::new(LanceDbBackend::new(data_dir, dim)?))

--- a/crates/sapphire-retrieve/src/lancedb_store.rs
+++ b/crates/sapphire-retrieve/src/lancedb_store.rs
@@ -43,7 +43,7 @@ use crate::{
     chunker::chunk_document,
     embed::Embedder,
     error::{Error, Result},
-    retrieve_store::{Document, RetrieveStore, SearchResult},
+    retrieve_store::{Document, FtsQuery, RetrieveStore, SearchResult, VectorQuery},
     vector_store::{Chunk, ChunkSearchResult, VecInfo},
 };
 
@@ -327,8 +327,13 @@ impl LanceFullStore {
         Ok(())
     }
 
-    async fn search_fts(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
-        let batches: Vec<RecordBatch> = self
+    async fn search_fts(
+        &self,
+        query: &str,
+        limit: usize,
+        path_prefix: Option<&str>,
+    ) -> Result<Vec<SearchResult>> {
+        let mut qb = self
             .documents
             .query()
             .full_text_search(FullTextSearchQuery::new(query.to_owned()))
@@ -337,7 +342,14 @@ impl LanceFullStore {
                 "title".to_string(),
                 "path".to_string(),
             ]))
-            .limit(limit)
+            .limit(limit);
+        if let Some(pfx) = path_prefix {
+            qb = qb.only_if(format!(
+                "path LIKE '{}%'",
+                escape_sql_string(pfx)
+            ));
+        }
+        let batches: Vec<RecordBatch> = qb
             .execute()
             .await?
             .try_collect()
@@ -379,13 +391,21 @@ impl LanceFullStore {
         &self,
         query_vec: &[f32],
         limit: usize,
+        path_prefix: Option<&str>,
     ) -> Result<Vec<ChunkSearchResult>> {
-        let batches: Vec<RecordBatch> = self
+        let mut qb = self
             .chunk_vectors
             .vector_search(query_vec)
             .map_err(|e| Error::Embed(e.to_string()))?
             .column("embedding")
-            .limit(limit)
+            .limit(limit);
+        if let Some(pfx) = path_prefix {
+            qb = qb.only_if(format!(
+                "doc_path LIKE '{}%'",
+                escape_sql_string(pfx)
+            ));
+        }
+        let batches: Vec<RecordBatch> = qb
             .execute()
             .await?
             .try_collect()
@@ -669,18 +689,22 @@ impl LanceDbBackend {
         self.block_on(self.inner.rebuild_fts())
     }
 
-    pub fn search_fts(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
-        self.block_on(self.inner.search_fts(query, limit))
+    pub fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<SearchResult>> {
+        let pfx = q.path_prefix.map(|p| p.to_string_lossy().to_string());
+        self.block_on(
+            self.inner
+                .search_fts(q.query, q.limit, pfx.as_deref()),
+        )
     }
 
     // ── vector search ─────────────────────────────────────────────────────────
 
-    pub fn search_similar(
-        &self,
-        query_vec: &[f32],
-        limit: usize,
-    ) -> Result<Vec<ChunkSearchResult>> {
-        self.block_on(self.inner.search_similar(query_vec, limit))
+    pub fn search_similar(&self, q: &VectorQuery<'_>) -> Result<Vec<ChunkSearchResult>> {
+        let pfx = q.path_prefix.map(|p| p.to_string_lossy().to_string());
+        self.block_on(
+            self.inner
+                .search_similar(q.query_vec, q.limit, pfx.as_deref()),
+        )
     }
 
     // ── embedding ─────────────────────────────────────────────────────────────
@@ -751,8 +775,8 @@ impl RetrieveStore for LanceDbBackend {
         self.rebuild_fts()
     }
 
-    fn search_fts(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
-        self.search_fts(query, limit)
+    fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<SearchResult>> {
+        self.search_fts(q)
     }
 
     fn document_ids(&self) -> Result<Vec<i64>> {
@@ -775,7 +799,7 @@ impl RetrieveStore for LanceDbBackend {
         self.vec_info()
     }
 
-    fn search_similar(&self, query_vec: &[f32], limit: usize) -> Result<Vec<ChunkSearchResult>> {
-        self.search_similar(query_vec, limit)
+    fn search_similar(&self, q: &VectorQuery<'_>) -> Result<Vec<ChunkSearchResult>> {
+        self.search_similar(q)
     }
 }

--- a/crates/sapphire-retrieve/src/lancedb_store.rs
+++ b/crates/sapphire-retrieve/src/lancedb_store.rs
@@ -1,26 +1,22 @@
 #![cfg(feature = "lancedb-store")]
 //! Full LanceDB backend for [`RetrieveDb`].
 //!
-//! When LanceDB is selected as the vector backend, this module provides an
-//! implementation that stores *all* data — files, documents, chunks, and
-//! embeddings — in LanceDB, with no SQLite dependency.
+//! When LanceDB is selected as the vector backend, this module stores *all*
+//! data — files, documents, chunks, and embeddings — in LanceDB tables.
 //!
 //! # Tables
 //!
-//! | table           | columns                                                       | purpose                         |
-//! |-----------------|---------------------------------------------------------------|---------------------------------|
-//! | `files`         | `path Utf8, mtime Int64`                                      | file mtime tracking             |
-//! | `documents`     | `id Int64, title Utf8, body Utf8, path Utf8`                  | FTS index source                |
-//! | `chunks_meta`   | `doc_id Int64, line Int32, col Int32, text Utf8, doc_title Utf8, doc_path Utf8` | pending-embedding tracking |
-//! | `chunk_vectors` | `doc_id Int64, line Int32, col Int32, doc_title Utf8, doc_path Utf8, text Utf8, embedding FixedSizeList<Float32>` | vector search |
+//! | table           | columns                                                                                          |
+//! |-----------------|--------------------------------------------------------------------------------------------------|
+//! | `files`         | `path Utf8, mtime Int64`                                                                         |
+//! | `documents`     | `id Int64, title Utf8, path Utf8`                                                                |
+//! | `chunks_meta`   | `doc_id Int64, line_start Int32, line_end Int32, text Utf8, doc_title Utf8, doc_path Utf8`       |
+//! | `chunk_vectors` | `doc_id Int64, line_start Int32, line_end Int32, doc_title Utf8, doc_path Utf8, text Utf8, embedding FixedSizeList<Float32>` |
 //!
-//! # Directory layout
-//!
-//! All tables live inside `{root}/lancedb_full_v{SCHEMA_VERSION}/`.
-//! This is distinct from the old hybrid-mode directory `lancedb_v1/`.
+//! FTS is built on `chunks_meta.text` (chunk-level).
 
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -43,8 +39,10 @@ use crate::{
     chunker::chunk_document,
     embed::Embedder,
     error::{Error, Result},
-    retrieve_store::{Document, FtsQuery, RetrieveStore, SearchResult, VectorQuery},
-    vector_store::{Chunk, ChunkSearchResult, VecInfo},
+    retrieve_store::{
+        ChunkHit, Document, FileSearchResult, FtsQuery, RetrieveStore, VectorQuery,
+    },
+    vector_store::{Chunk, VecInfo},
 };
 
 // ── versioning ────────────────────────────────────────────────────────────────
@@ -55,7 +53,8 @@ use crate::{
 /// - 1: initial schema
 /// - 2: LanceDB full-backend
 /// - 3: replace `chunk_index` with `line` + `col` (source positions)
-pub const SCHEMA_VERSION: i32 = 3;
+/// - 4: chunk-level FTS, `line_start`/`line_end`, drop `documents.body`
+pub const SCHEMA_VERSION: i32 = 4;
 
 /// Returns the full-backend LanceDB directory for the given cache root.
 pub fn data_dir(root: &Path) -> PathBuf {
@@ -82,7 +81,6 @@ fn documents_schema() -> Arc<Schema> {
     Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int64, false),
         Field::new("title", DataType::Utf8, false),
-        Field::new("body", DataType::Utf8, false),
         Field::new("path", DataType::Utf8, false),
     ]))
 }
@@ -90,8 +88,8 @@ fn documents_schema() -> Arc<Schema> {
 fn chunks_meta_schema() -> Arc<Schema> {
     Arc::new(Schema::new(vec![
         Field::new("doc_id", DataType::Int64, false),
-        Field::new("line", DataType::Int32, false),
-        Field::new("col", DataType::Int32, false),
+        Field::new("line_start", DataType::Int32, false),
+        Field::new("line_end", DataType::Int32, false),
         Field::new("text", DataType::Utf8, false),
         Field::new("doc_title", DataType::Utf8, false),
         Field::new("doc_path", DataType::Utf8, false),
@@ -101,8 +99,8 @@ fn chunks_meta_schema() -> Arc<Schema> {
 fn chunk_vectors_schema(dim: i32) -> Arc<Schema> {
     Arc::new(Schema::new(vec![
         Field::new("doc_id", DataType::Int64, false),
-        Field::new("line", DataType::Int32, false),
-        Field::new("col", DataType::Int32, false),
+        Field::new("line_start", DataType::Int32, false),
+        Field::new("line_end", DataType::Int32, false),
         Field::new("doc_title", DataType::Utf8, false),
         Field::new("doc_path", DataType::Utf8, false),
         Field::new("text", DataType::Utf8, false),
@@ -181,10 +179,10 @@ impl LanceFullStore {
 
     // ── file tracking ─────────────────────────────────────────────────────────
 
-    async fn file_mtimes(&self) -> Result<std::collections::HashMap<String, i64>> {
+    async fn file_mtimes(&self) -> Result<HashMap<String, i64>> {
         let batches: Vec<RecordBatch> = self.files.query().execute().await?.try_collect().await?;
 
-        let mut map = std::collections::HashMap::new();
+        let mut map = HashMap::new();
         for batch in &batches {
             let paths = batch
                 .column_by_name("path")
@@ -235,14 +233,12 @@ impl LanceFullStore {
     // ── document management ───────────────────────────────────────────────────
 
     async fn upsert_document(&self, doc: &Document) -> Result<()> {
-        // Upsert into documents table.
         let schema = documents_schema();
         let batch = RecordBatch::try_new(
             schema.clone(),
             vec![
                 Arc::new(Int64Array::from(vec![doc.id])),
                 Arc::new(StringArray::from(vec![doc.title.as_str()])),
-                Arc::new(StringArray::from(vec![doc.body.as_str()])),
                 Arc::new(StringArray::from(vec![doc.path.as_str()])),
             ],
         )
@@ -264,7 +260,7 @@ impl LanceFullStore {
             .delete(&format!("doc_id = {}", doc.id))
             .await?;
 
-        // Build (line, col, embed_text) tuples.
+        // Build (line_start, line_end, embed_text) tuples.
         let computed: Vec<(usize, usize, String)>;
         let chunks: &[(usize, usize, String)] = if let Some(ref c) = doc.chunks {
             c.as_slice()
@@ -272,7 +268,7 @@ impl LanceFullStore {
             computed = chunk_document(&doc.title, &doc.body)
                 .into_iter()
                 .enumerate()
-                .map(|(i, t)| (i, 0usize, t))
+                .map(|(i, t)| (i, i, t))
                 .collect();
             &computed
         };
@@ -284,8 +280,8 @@ impl LanceFullStore {
         let schema = chunks_meta_schema();
         let n = chunks.len();
         let doc_ids = vec![doc.id; n];
-        let lines: Vec<i32> = chunks.iter().map(|(l, _, _)| *l as i32).collect();
-        let cols: Vec<i32> = chunks.iter().map(|(_, c, _)| *c as i32).collect();
+        let line_starts: Vec<i32> = chunks.iter().map(|(s, _, _)| *s as i32).collect();
+        let line_ends: Vec<i32> = chunks.iter().map(|(_, e, _)| *e as i32).collect();
         let titles = vec![doc.title.as_str(); n];
         let paths = vec![doc.path.as_str(); n];
         let texts: Vec<&str> = chunks.iter().map(|(_, _, t)| t.as_str()).collect();
@@ -294,8 +290,8 @@ impl LanceFullStore {
             schema.clone(),
             vec![
                 Arc::new(Int64Array::from(doc_ids)),
-                Arc::new(Int32Array::from(lines)),
-                Arc::new(Int32Array::from(cols)),
+                Arc::new(Int32Array::from(line_starts)),
+                Arc::new(Int32Array::from(line_ends)),
                 Arc::new(StringArray::from(texts)),
                 Arc::new(StringArray::from(titles)),
                 Arc::new(StringArray::from(paths)),
@@ -316,9 +312,9 @@ impl LanceFullStore {
     }
 
     async fn rebuild_fts(&self) -> Result<()> {
-        self.documents
+        self.chunks_meta
             .create_index(
-                &["title", "body"],
+                &["text"],
                 Index::FTS(FtsIndexBuilder::default().base_tokenizer("ngram".to_owned())),
             )
             .replace(true)
@@ -327,104 +323,109 @@ impl LanceFullStore {
         Ok(())
     }
 
+    // ── search ────────────────────────────────────────────────────────────────
+
     async fn search_fts(
         &self,
         query: &str,
         limit: usize,
         path_prefix: Option<&str>,
-    ) -> Result<Vec<SearchResult>> {
+    ) -> Result<Vec<FileSearchResult>> {
+        let over_fetch = limit.saturating_mul(5);
         let mut qb = self
-            .documents
+            .chunks_meta
             .query()
             .full_text_search(FullTextSearchQuery::new(query.to_owned()))
             .select(Select::Columns(vec![
-                "id".to_string(),
-                "title".to_string(),
-                "path".to_string(),
+                "doc_id".to_string(),
+                "doc_title".to_string(),
+                "doc_path".to_string(),
+                "line_start".to_string(),
+                "line_end".to_string(),
+                "text".to_string(),
             ]))
-            .limit(limit);
+            .limit(over_fetch);
         if let Some(pfx) = path_prefix {
-            qb = qb.only_if(format!(
-                "path LIKE '{}%'",
-                escape_sql_string(pfx)
-            ));
+            qb = qb.only_if(format!("doc_path LIKE '{}%'", escape_sql_string(pfx)));
         }
-        let batches: Vec<RecordBatch> = qb
-            .execute()
-            .await?
-            .try_collect()
-            .await?;
+        let batches: Vec<RecordBatch> = qb.execute().await?.try_collect().await?;
 
-        let mut results = Vec::new();
+        let mut rows = Vec::new();
         for batch in &batches {
-            let ids = batch
-                .column_by_name("id")
+            let doc_ids = batch
+                .column_by_name("doc_id")
                 .and_then(|c| c.as_any().downcast_ref::<Int64Array>());
             let titles = batch
-                .column_by_name("title")
+                .column_by_name("doc_title")
                 .and_then(|c| c.as_any().downcast_ref::<StringArray>());
             let paths = batch
-                .column_by_name("path")
+                .column_by_name("doc_path")
                 .and_then(|c| c.as_any().downcast_ref::<StringArray>());
-            // _score is positive BM25 score (higher = more relevant)
+            let line_starts = batch
+                .column_by_name("line_start")
+                .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
+            let line_ends = batch
+                .column_by_name("line_end")
+                .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
+            let texts = batch
+                .column_by_name("text")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
             let scores = batch
                 .column_by_name("_score")
                 .and_then(|c| c.as_any().downcast_ref::<Float32Array>());
 
-            if let (Some(ids), Some(titles), Some(paths)) = (ids, titles, paths) {
+            if let (Some(dids), Some(ttls), Some(pths), Some(ls), Some(le), Some(txts)) =
+                (doc_ids, titles, paths, line_starts, line_ends, texts)
+            {
                 for i in 0..batch.num_rows() {
-                    results.push(SearchResult {
-                        id: ids.value(i),
-                        title: titles.value(i).to_owned(),
-                        path: paths.value(i).to_owned(),
+                    rows.push(RawHit {
+                        doc_id: dids.value(i),
+                        title: ttls.value(i).to_owned(),
+                        path: pths.value(i).to_owned(),
+                        line_start: ls.value(i) as usize,
+                        line_end: le.value(i) as usize,
+                        text: txts.value(i).to_owned(),
                         score: scores.map_or(0.0, |s| s.value(i) as f64),
                     });
                 }
             }
         }
-        Ok(results)
+        // BM25 _score: higher = more relevant.
+        Ok(group_by_file(rows, limit, |a, b| a > b))
     }
-
-    // ── vector search ─────────────────────────────────────────────────────────
 
     async fn search_similar(
         &self,
         query_vec: &[f32],
         limit: usize,
         path_prefix: Option<&str>,
-    ) -> Result<Vec<ChunkSearchResult>> {
+    ) -> Result<Vec<FileSearchResult>> {
+        let over_fetch = limit.saturating_mul(5);
         let mut qb = self
             .chunk_vectors
             .vector_search(query_vec)
             .map_err(|e| Error::Embed(e.to_string()))?
             .column("embedding")
-            .limit(limit);
+            .limit(over_fetch);
         if let Some(pfx) = path_prefix {
-            qb = qb.only_if(format!(
-                "doc_path LIKE '{}%'",
-                escape_sql_string(pfx)
-            ));
+            qb = qb.only_if(format!("doc_path LIKE '{}%'", escape_sql_string(pfx)));
         }
-        let batches: Vec<RecordBatch> = qb
-            .execute()
-            .await?
-            .try_collect()
-            .await?;
+        let batches: Vec<RecordBatch> = qb.execute().await?.try_collect().await?;
 
-        let mut results = Vec::new();
+        let mut rows = Vec::new();
         for batch in &batches {
             let doc_ids = batch
                 .column_by_name("doc_id")
                 .and_then(|c| c.as_any().downcast_ref::<Int64Array>())
                 .ok_or_else(|| Error::Embed("missing `doc_id` in search result".into()))?;
-            let lines = batch
-                .column_by_name("line")
+            let line_starts = batch
+                .column_by_name("line_start")
                 .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
-                .ok_or_else(|| Error::Embed("missing `line` in search result".into()))?;
-            let cols = batch
-                .column_by_name("col")
+                .ok_or_else(|| Error::Embed("missing `line_start` in search result".into()))?;
+            let line_ends = batch
+                .column_by_name("line_end")
                 .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
-                .ok_or_else(|| Error::Embed("missing `col` in search result".into()))?;
+                .ok_or_else(|| Error::Embed("missing `line_end` in search result".into()))?;
             let titles = batch
                 .column_by_name("doc_title")
                 .and_then(|c| c.as_any().downcast_ref::<StringArray>())
@@ -443,18 +444,19 @@ impl LanceFullStore {
                 .ok_or_else(|| Error::Embed("missing `_distance` in search result".into()))?;
 
             for i in 0..batch.num_rows() {
-                results.push(ChunkSearchResult {
+                rows.push(RawHit {
                     doc_id: doc_ids.value(i),
-                    line: lines.value(i) as usize,
-                    column: cols.value(i) as usize,
-                    doc_title: titles.value(i).to_owned(),
-                    doc_path: paths.value(i).to_owned(),
-                    chunk_text: texts.value(i).to_owned(),
+                    title: titles.value(i).to_owned(),
+                    path: paths.value(i).to_owned(),
+                    line_start: line_starts.value(i) as usize,
+                    line_end: line_ends.value(i) as usize,
+                    text: texts.value(i).to_owned(),
                     score: dists.value(i) as f64,
                 });
             }
         }
-        Ok(results)
+        // Vector distance: lower = better.
+        Ok(group_by_file(rows, limit, |a, b| a < b))
     }
 
     // ── embedding ─────────────────────────────────────────────────────────────
@@ -465,7 +467,7 @@ impl LanceFullStore {
             .query()
             .select(Select::Columns(vec![
                 "doc_id".to_string(),
-                "line".to_string(),
+                "line_start".to_string(),
             ]))
             .execute()
             .await?
@@ -477,10 +479,10 @@ impl LanceFullStore {
             let doc_ids = batch
                 .column_by_name("doc_id")
                 .and_then(|c| c.as_any().downcast_ref::<Int64Array>());
-            let lines = batch
-                .column_by_name("line")
+            let line_starts = batch
+                .column_by_name("line_start")
                 .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
-            if let (Some(dids), Some(ls)) = (doc_ids, lines) {
+            if let (Some(dids), Some(ls)) = (doc_ids, line_starts) {
                 for i in 0..batch.num_rows() {
                     keys.insert((dids.value(i), ls.value(i) as usize));
                 }
@@ -503,11 +505,11 @@ impl LanceFullStore {
             let doc_ids = batch
                 .column_by_name("doc_id")
                 .and_then(|c| c.as_any().downcast_ref::<Int64Array>());
-            let lines = batch
-                .column_by_name("line")
+            let line_starts = batch
+                .column_by_name("line_start")
                 .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
-            let cols = batch
-                .column_by_name("col")
+            let line_ends = batch
+                .column_by_name("line_end")
                 .and_then(|c| c.as_any().downcast_ref::<Int32Array>());
             let texts = batch
                 .column_by_name("text")
@@ -519,16 +521,16 @@ impl LanceFullStore {
                 .column_by_name("doc_path")
                 .and_then(|c| c.as_any().downcast_ref::<StringArray>());
 
-            if let (Some(dids), Some(ls), Some(cs), Some(txts), Some(ttls), Some(pths)) =
-                (doc_ids, lines, cols, texts, titles, paths)
+            if let (Some(dids), Some(ls), Some(le), Some(txts), Some(ttls), Some(pths)) =
+                (doc_ids, line_starts, line_ends, texts, titles, paths)
             {
                 for i in 0..batch.num_rows() {
                     let key = (dids.value(i), ls.value(i) as usize);
                     if !embedded.contains(&key) {
                         chunks.push(Chunk {
                             doc_id: key.0,
-                            line: key.1,
-                            column: cs.value(i) as usize,
+                            line_start: key.1,
+                            line_end: le.value(i) as usize,
                             text: txts.value(i).to_owned(),
                             doc_title: ttls.value(i).to_owned(),
                             doc_path: pths.value(i).to_owned(),
@@ -546,8 +548,8 @@ impl LanceFullStore {
         }
         let schema = chunk_vectors_schema(self.dim);
         let doc_ids: Vec<i64> = chunks.iter().map(|c| c.doc_id).collect();
-        let lines: Vec<i32> = chunks.iter().map(|c| c.line as i32).collect();
-        let cols: Vec<i32> = chunks.iter().map(|c| c.column as i32).collect();
+        let line_starts: Vec<i32> = chunks.iter().map(|c| c.line_start as i32).collect();
+        let line_ends: Vec<i32> = chunks.iter().map(|c| c.line_end as i32).collect();
         let titles: Vec<&str> = chunks.iter().map(|c| c.doc_title.as_str()).collect();
         let paths: Vec<&str> = chunks.iter().map(|c| c.doc_path.as_str()).collect();
         let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
@@ -556,8 +558,8 @@ impl LanceFullStore {
             schema.clone(),
             vec![
                 Arc::new(Int64Array::from(doc_ids)),
-                Arc::new(Int32Array::from(lines)),
-                Arc::new(Int32Array::from(cols)),
+                Arc::new(Int32Array::from(line_starts)),
+                Arc::new(Int32Array::from(line_ends)),
                 Arc::new(StringArray::from(titles)),
                 Arc::new(StringArray::from(paths)),
                 Arc::new(StringArray::from(texts)),
@@ -611,10 +613,70 @@ impl LanceFullStore {
     }
 }
 
+// ── raw hit + grouping ────────────────────────────────────────────────────────
+
+struct RawHit {
+    doc_id: i64,
+    title: String,
+    path: String,
+    line_start: usize,
+    line_end: usize,
+    text: String,
+    score: f64,
+}
+
+fn group_by_file<F>(rows: Vec<RawHit>, limit: usize, is_better: F) -> Vec<FileSearchResult>
+where
+    F: Fn(f64, f64) -> bool + Copy,
+{
+    let mut by_doc: HashMap<i64, FileSearchResult> = HashMap::new();
+
+    for r in rows {
+        let entry = by_doc.entry(r.doc_id).or_insert_with(|| FileSearchResult {
+            id: r.doc_id,
+            title: r.title.clone(),
+            path: r.path.clone(),
+            score: r.score,
+            chunks: Vec::new(),
+        });
+        if is_better(r.score, entry.score) {
+            entry.score = r.score;
+        }
+        entry.chunks.push(ChunkHit {
+            line_start: r.line_start,
+            line_end: r.line_end,
+            text: r.text,
+            score: r.score,
+        });
+    }
+
+    let mut files: Vec<FileSearchResult> = by_doc.into_values().collect();
+    for f in &mut files {
+        f.chunks.sort_by(|a, b| {
+            if is_better(a.score, b.score) {
+                std::cmp::Ordering::Less
+            } else if is_better(b.score, a.score) {
+                std::cmp::Ordering::Greater
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        });
+    }
+    files.sort_by(|a, b| {
+        if is_better(a.score, b.score) {
+            std::cmp::Ordering::Less
+        } else if is_better(b.score, a.score) {
+            std::cmp::Ordering::Greater
+        } else {
+            std::cmp::Ordering::Equal
+        }
+    });
+    files.truncate(limit);
+    files
+}
+
 // ── public sync wrapper ───────────────────────────────────────────────────────
 
-/// Full LanceDB backend: stores files, documents, chunks, and embeddings
-/// entirely within LanceDB — no SQLite required.
 pub(crate) struct LanceDbBackend {
     inner: LanceFullStore,
     rt: tokio::runtime::Runtime,
@@ -635,17 +697,6 @@ impl LanceDbBackend {
         })
     }
 
-    /// Run a future to completion, safely handling the case where we are
-    /// already executing inside a Tokio runtime.
-    ///
-    /// - **Outside a runtime**: delegates to `rt.block_on(f)`.
-    /// - **Inside a multi-thread runtime**: uses `tokio::task::block_in_place`
-    ///   so that other tasks on the thread pool can continue running while
-    ///   this thread blocks.
-    ///
-    /// Note: `block_in_place` panics when the *outer* runtime uses
-    /// `flavor = "current_thread"`.  In that case callers should move the
-    /// call to `spawn_blocking` before reaching this code.
     fn block_on_with<F: std::future::Future>(rt: &tokio::runtime::Runtime, f: F) -> F::Output {
         match tokio::runtime::Handle::try_current() {
             Ok(handle) => tokio::task::block_in_place(|| handle.block_on(f)),
@@ -659,7 +710,7 @@ impl LanceDbBackend {
 
     // ── file tracking ─────────────────────────────────────────────────────────
 
-    pub fn file_mtimes(&self) -> Result<std::collections::HashMap<String, i64>> {
+    pub fn file_mtimes(&self) -> Result<HashMap<String, i64>> {
         self.block_on(self.inner.file_mtimes())
     }
 
@@ -689,21 +740,23 @@ impl LanceDbBackend {
         self.block_on(self.inner.rebuild_fts())
     }
 
-    pub fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<SearchResult>> {
+    pub fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<FileSearchResult>> {
         let pfx = q.path_prefix.map(|p| p.to_string_lossy().to_string());
-        self.block_on(
-            self.inner
-                .search_fts(q.query, q.limit, pfx.as_deref()),
-        )
+        self.block_on(self.inner.search_fts(q.query, q.limit, pfx.as_deref()))
     }
 
     // ── vector search ─────────────────────────────────────────────────────────
 
-    pub fn search_similar(&self, q: &VectorQuery<'_>) -> Result<Vec<ChunkSearchResult>> {
+    pub fn search_similar(&self, q: &VectorQuery<'_>) -> Result<Vec<FileSearchResult>> {
+        let query_vecs = q.embedder.embed_texts(&[q.query])?;
+        let query_vec = query_vecs
+            .into_iter()
+            .next()
+            .ok_or_else(|| Error::Embed("embedder returned empty result".into()))?;
         let pfx = q.path_prefix.map(|p| p.to_string_lossy().to_string());
         self.block_on(
             self.inner
-                .search_similar(q.query_vec, q.limit, pfx.as_deref()),
+                .search_similar(&query_vec, q.limit, pfx.as_deref()),
         )
     }
 
@@ -747,7 +800,7 @@ impl LanceDbBackend {
 // ── RetrieveStore impl ────────────────────────────────────────────────────────
 
 impl RetrieveStore for LanceDbBackend {
-    fn file_mtimes(&self) -> Result<std::collections::HashMap<String, i64>> {
+    fn file_mtimes(&self) -> Result<HashMap<String, i64>> {
         self.file_mtimes()
     }
 
@@ -775,7 +828,7 @@ impl RetrieveStore for LanceDbBackend {
         self.rebuild_fts()
     }
 
-    fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<SearchResult>> {
+    fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<FileSearchResult>> {
         self.search_fts(q)
     }
 
@@ -799,7 +852,7 @@ impl RetrieveStore for LanceDbBackend {
         self.vec_info()
     }
 
-    fn search_similar(&self, q: &VectorQuery<'_>) -> Result<Vec<ChunkSearchResult>> {
+    fn search_similar(&self, q: &VectorQuery<'_>) -> Result<Vec<FileSearchResult>> {
         self.search_similar(q)
     }
 }

--- a/crates/sapphire-retrieve/src/lib.rs
+++ b/crates/sapphire-retrieve/src/lib.rs
@@ -15,10 +15,12 @@ pub use config::{EmbeddingConfig, HybridConfig, RetrieveConfig, VectorDb};
 pub use db::open_in_memory;
 #[cfg(feature = "lancedb-store")]
 pub use db::open_lancedb;
-pub use db::{Document, RetrieveDb, SearchResult, dedup_chunk_results, default_hybrid, merge_rrf};
+pub use db::{RetrieveDb, default_hybrid, merge_rrf_files};
 #[cfg(feature = "sqlite-store")]
 pub use db::{open_sqlite_fts, open_sqlite_vec};
 pub use embed::{Embedder, EmbedderConfig, build_embedder};
 pub use error::{Error, Result};
-pub use retrieve_store::{FtsQuery, HybridQuery, RetrieveStore, VectorQuery};
-pub use vector_store::{Chunk, ChunkSearchResult, VecInfo, VectorStore};
+pub use retrieve_store::{
+    ChunkHit, Document, FileSearchResult, FtsQuery, HybridQuery, RetrieveStore, VectorQuery,
+};
+pub use vector_store::{Chunk, VecInfo};

--- a/crates/sapphire-retrieve/src/lib.rs
+++ b/crates/sapphire-retrieve/src/lib.rs
@@ -15,10 +15,10 @@ pub use config::{EmbeddingConfig, HybridConfig, RetrieveConfig, VectorDb};
 pub use db::open_in_memory;
 #[cfg(feature = "lancedb-store")]
 pub use db::open_lancedb;
-pub use db::{Document, RetrieveDb, SearchResult, dedup_chunk_results};
+pub use db::{Document, RetrieveDb, SearchResult, dedup_chunk_results, default_hybrid, merge_rrf};
 #[cfg(feature = "sqlite-store")]
 pub use db::{open_sqlite_fts, open_sqlite_vec};
 pub use embed::{Embedder, EmbedderConfig, build_embedder};
 pub use error::{Error, Result};
-pub use retrieve_store::RetrieveStore;
+pub use retrieve_store::{FtsQuery, HybridQuery, RetrieveStore, VectorQuery};
 pub use vector_store::{Chunk, ChunkSearchResult, VecInfo, VectorStore};

--- a/crates/sapphire-retrieve/src/retrieve_store.rs
+++ b/crates/sapphire-retrieve/src/retrieve_store.rs
@@ -4,12 +4,6 @@
 //! storage backends (SQLite-vec, LanceDB, and future backends such as
 //! SurrealDB).
 //!
-//! # Implementing a custom backend
-//!
-//! Implement [`RetrieveStore`] for your struct, then pass an `Arc` of it to
-//! the relevant `init_*` method on [`crate::db::RetrieveDb`], or build a
-//! `RetrieveDb` directly from it (see [`crate::db::RetrieveDb::from_backend`]).
-//!
 //! All methods are **synchronous**.  Async backends must wrap their async
 //! operations inside a dedicated Tokio runtime.
 
@@ -19,7 +13,7 @@ use std::path::Path;
 use crate::{
     embed::Embedder,
     error::Result,
-    vector_store::{ChunkSearchResult, VecInfo},
+    vector_store::VecInfo,
 };
 
 // ── query structs ────────────────────────────────────────────────────────────
@@ -27,8 +21,12 @@ use crate::{
 /// Full-text search query.
 #[derive(Debug, Clone)]
 pub struct FtsQuery<'a> {
+    /// Query text.
     pub query: &'a str,
+    /// Maximum number of file-level results.
     pub limit: usize,
+    /// When set, restrict results to documents whose `path` starts with this
+    /// absolute prefix.
     pub path_prefix: Option<&'a Path>,
 }
 
@@ -52,18 +50,22 @@ impl<'a> FtsQuery<'a> {
     }
 }
 
-/// Vector similarity search query (chunk-level).
-#[derive(Debug, Clone)]
+/// Vector (semantic) similarity query.
+///
+/// The backend embeds `query` using `embedder` internally, so callers don't
+/// need to pre-compute the vector.
 pub struct VectorQuery<'a> {
-    pub query_vec: &'a [f32],
+    pub query: &'a str,
+    pub embedder: &'a dyn Embedder,
     pub limit: usize,
     pub path_prefix: Option<&'a Path>,
 }
 
 impl<'a> VectorQuery<'a> {
-    pub fn new(query_vec: &'a [f32]) -> Self {
+    pub fn new(query: &'a str, embedder: &'a dyn Embedder) -> Self {
         Self {
-            query_vec,
+            query,
+            embedder,
             limit: 10,
             path_prefix: None,
         }
@@ -80,11 +82,22 @@ impl<'a> VectorQuery<'a> {
     }
 }
 
+impl std::fmt::Debug for VectorQuery<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VectorQuery")
+            .field("query", &self.query)
+            .field("limit", &self.limit)
+            .field("path_prefix", &self.path_prefix)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Hybrid (FTS + vector) search query, merged via Reciprocal Rank Fusion.
-#[derive(Debug, Clone)]
+///
+/// When `embedder` is `None`, falls back to FTS-only.
 pub struct HybridQuery<'a> {
-    pub text: &'a str,
-    pub query_vec: &'a [f32],
+    pub query: &'a str,
+    pub embedder: Option<&'a dyn Embedder>,
     pub limit: usize,
     pub path_prefix: Option<&'a Path>,
     pub rrf_k: f64,
@@ -93,16 +106,21 @@ pub struct HybridQuery<'a> {
 }
 
 impl<'a> HybridQuery<'a> {
-    pub fn new(text: &'a str, query_vec: &'a [f32]) -> Self {
+    pub fn new(query: &'a str) -> Self {
         Self {
-            text,
-            query_vec,
+            query,
+            embedder: None,
             limit: 10,
             path_prefix: None,
             rrf_k: 60.0,
             weight_fts: 1.0,
             weight_sem: 1.0,
         }
+    }
+
+    pub fn embedder(mut self, e: &'a dyn Embedder) -> Self {
+        self.embedder = Some(e);
+        self
     }
 
     pub fn limit(mut self, n: usize) -> Self {
@@ -131,148 +149,122 @@ impl<'a> HybridQuery<'a> {
     }
 }
 
+impl std::fmt::Debug for HybridQuery<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HybridQuery")
+            .field("query", &self.query)
+            .field("limit", &self.limit)
+            .field("path_prefix", &self.path_prefix)
+            .field("rrf_k", &self.rrf_k)
+            .field("weight_fts", &self.weight_fts)
+            .field("weight_sem", &self.weight_sem)
+            .finish_non_exhaustive()
+    }
+}
+
 // ── shared domain types ───────────────────────────────────────────────────────
 
 /// A document to be indexed for FTS and/or vector search.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Document {
     /// Stable identifier assigned by the caller.
-    ///
-    /// For sapphire-journal, this is the `CarettaId` stored as `i64`.  For
-    /// other applications, a hash of the file path works well.
     pub id: i64,
     /// Human-readable title (shown in search results).
     pub title: String,
-    /// Full body text (indexed by FTS and chunked for vector embedding).
+    /// Full body text; used only as input to the chunker when `chunks` is `None`.
+    /// Not persisted to the database.
     pub body: String,
     /// Absolute file path (shown in search results).
     pub path: String,
-    /// Pre-computed text chunks with source-location positions.
+    /// Pre-computed text chunks with source-location ranges.
     ///
-    /// Each element is `(line, column, embed_text)` where:
-    ///
-    /// - `line` — 0-based source line number stored as the `line` column in the
-    ///   database.  Returned verbatim in
-    ///   [`ChunkSearchResult::line`](crate::vector_store::ChunkSearchResult::line)
-    ///   so a GUI can navigate directly to the source location.
-    /// - `column` — 0-based byte offset within `line`.
-    /// - `embed_text` — title-prepended chunk text used for vector embedding
-    ///   (the same format that [`crate::chunker::chunk_document`] produces).
-    ///
-    /// When `None`, the storage backend falls back to auto-chunking `body` via
-    /// [`crate::chunker::chunk_document`] with sequential 0-based `line` values.
+    /// Each element is `(line_start, line_end, embed_text)` where the line
+    /// values are 0-based and inclusive.  When `None`, the storage backend
+    /// falls back to auto-chunking `body` via [`crate::chunker::chunk_document`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chunks: Option<Vec<(usize, usize, String)>>,
 }
 
-/// A search result from [`RetrieveStore::search_fts`] or a deduplicated
-/// result from [`crate::db::RetrieveDb::dedup_chunk_results`].
+/// A single chunk match inside a [`FileSearchResult`].
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct SearchResult {
+pub struct ChunkHit {
+    /// First source line of the matched chunk (inclusive, 0-based).
+    pub line_start: usize,
+    /// Last source line of the matched chunk (inclusive, 0-based).
+    pub line_end: usize,
+    /// The chunk's extracted text.
+    pub text: String,
+    /// Per-chunk score: FTS rank (lower = better), vector L2 distance
+    /// (lower = better), or RRF score (higher = better), depending on the
+    /// search mode.
+    pub score: f64,
+}
+
+/// File-level search result with one or more matched chunks.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FileSearchResult {
     pub id: i64,
     pub title: String,
     pub path: String,
-    /// BM25 rank (FTS; negative: more-negative = more relevant) or
-    /// L2 distance (vector; lower = more similar).
+    /// Representative score for the file (best chunk for FTS/vector,
+    /// aggregated RRF score for hybrid).
     pub score: f64,
+    /// Matched chunks within this file, ordered by per-chunk score.
+    pub chunks: Vec<ChunkHit>,
 }
 
 // ── trait ─────────────────────────────────────────────────────────────────────
 
 /// Unified synchronous interface for retrieve storage backends.
 ///
-/// All methods are **synchronous**.  Async backends (e.g. LanceDB) wrap their
-/// async operations in an internal Tokio runtime.
-///
 /// Built-in implementations:
-/// - [`SqliteStore`](crate::sqlite_store::SqliteStore) — SQLite-vec backend
-///   (always available, lightweight, default).
-/// - [`LanceDbBackend`](crate::lancedb_store::LanceDbBackend) — full LanceDB
-///   backend (requires the `lancedb-store` feature).
-///
-/// # Adding a new backend (e.g. SurrealDB)
-///
-/// 1. Implement `RetrieveStore` for your type.
-/// 2. Call [`RetrieveDb::from_backend`](crate::db::RetrieveDb::from_backend)
-///    with an `Arc` of your implementation.
+/// - [`SqliteStore`](crate::sqlite_store::SqliteStore) — SQLite-vec backend.
+/// - [`LanceDbBackend`](crate::lancedb_store::LanceDbBackend) — LanceDB backend
+///   (requires the `lancedb-store` feature).
 pub trait RetrieveStore: Send + Sync {
     // ── file tracking ──────────────────────────────────────────────────────────
 
-    /// Return all tracked `(path, mtime)` pairs.
     fn file_mtimes(&self) -> Result<HashMap<String, i64>>;
-
-    /// Insert or replace a file record.
     fn upsert_file(&self, path: &str, mtime: i64) -> Result<()>;
-
-    /// Delete a file record.
     fn remove_file(&self, path: &str) -> Result<()>;
-
-    /// Return the total number of tracked files.
     fn file_count(&self) -> Result<u64>;
 
     // ── document management ────────────────────────────────────────────────────
 
-    /// Insert or replace a document (also re-chunks the body).
-    ///
-    /// Call [`rebuild_fts`](Self::rebuild_fts) after a batch of upserts.
     fn upsert_document(&self, doc: &Document) -> Result<()>;
-
-    /// Remove a document and its chunks / embeddings.
-    ///
-    /// Performs an incremental FTS delete so a full rebuild is not needed
-    /// for single removals.
     fn remove_document(&self, id: i64) -> Result<()>;
 
-    /// Rebuild the FTS index from the current documents table.
-    ///
-    /// Call this after a batch of [`upsert_document`](Self::upsert_document)
-    /// calls or whenever the FTS index may be out of date.
+    /// Rebuild the FTS index.  Call after a batch of upserts.
     fn rebuild_fts(&self) -> Result<()>;
 
-    /// Full-text search; returns up to `limit` results ordered by relevance.
-    ///
-    /// When `q.path_prefix` is set, only documents whose path starts with
-    /// the given prefix are returned.
-    fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<SearchResult>>;
-
-    /// Return the IDs of all documents in the database.
     fn document_ids(&self) -> Result<Vec<i64>>;
-
-    /// Return the total number of documents.
     fn document_count(&self) -> Result<u64>;
 
-    // ── vector / embedding ─────────────────────────────────────────────────────
+    // ── embedding ──────────────────────────────────────────────────────────────
 
-    /// Generate and store embeddings for all pending (unembedded) chunks.
-    ///
-    /// `on_progress(done, total)` is called after each batch of 100 chunks.
-    /// Returns the number of newly embedded chunks (0 when no vector backend
-    /// is configured).
+    /// Generate and store embeddings for all pending chunks.
     fn embed_pending(
         &self,
         embedder: &dyn Embedder,
         on_progress: &dyn Fn(usize, usize),
     ) -> Result<usize>;
 
-    /// Return vector index statistics.
     fn vec_info(&self) -> Result<VecInfo>;
 
-    /// Find the `limit` most similar chunks to `query_vec`, ordered by
-    /// ascending distance.
-    ///
-    /// When `q.path_prefix` is set, only chunks belonging to documents
-    /// whose path starts with the given prefix are returned.
-    ///
-    /// Returns an empty `Vec` when no vector backend is configured.
-    fn search_similar(&self, q: &VectorQuery<'_>) -> Result<Vec<ChunkSearchResult>>;
+    // ── search ─────────────────────────────────────────────────────────────────
 
-    /// Hybrid search combining FTS and vector similarity via RRF.
+    /// Full-text search at chunk granularity, grouped per file.
+    fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<FileSearchResult>>;
+
+    /// Semantic (vector) search at chunk granularity, grouped per file.
     ///
-    /// The default implementation calls [`search_fts`](Self::search_fts) and
-    /// [`search_similar`](Self::search_similar), deduplicates chunks, and
-    /// merges via [`crate::db::merge_rrf`]. Backends may override for
-    /// native hybrid support.
-    fn search_hybrid(&self, q: &HybridQuery<'_>) -> Result<Vec<SearchResult>> {
+    /// The backend embeds `q.query` using `q.embedder` internally.
+    fn search_similar(&self, q: &VectorQuery<'_>) -> Result<Vec<FileSearchResult>>;
+
+    /// Hybrid search: runs FTS + vector and merges via RRF (default impl).
+    ///
+    /// If `q.embedder` is `None`, falls back to FTS-only.
+    fn search_hybrid(&self, q: &HybridQuery<'_>) -> Result<Vec<FileSearchResult>> {
         crate::db::default_hybrid(self, q)
     }
 }

--- a/crates/sapphire-retrieve/src/retrieve_store.rs
+++ b/crates/sapphire-retrieve/src/retrieve_store.rs
@@ -14,12 +14,122 @@
 //! operations inside a dedicated Tokio runtime.
 
 use std::collections::HashMap;
+use std::path::Path;
 
 use crate::{
     embed::Embedder,
     error::Result,
     vector_store::{ChunkSearchResult, VecInfo},
 };
+
+// ── query structs ────────────────────────────────────────────────────────────
+
+/// Full-text search query.
+#[derive(Debug, Clone)]
+pub struct FtsQuery<'a> {
+    pub query: &'a str,
+    pub limit: usize,
+    pub path_prefix: Option<&'a Path>,
+}
+
+impl<'a> FtsQuery<'a> {
+    pub fn new(query: &'a str) -> Self {
+        Self {
+            query,
+            limit: 10,
+            path_prefix: None,
+        }
+    }
+
+    pub fn limit(mut self, n: usize) -> Self {
+        self.limit = n;
+        self
+    }
+
+    pub fn path_prefix(mut self, p: &'a Path) -> Self {
+        self.path_prefix = Some(p);
+        self
+    }
+}
+
+/// Vector similarity search query (chunk-level).
+#[derive(Debug, Clone)]
+pub struct VectorQuery<'a> {
+    pub query_vec: &'a [f32],
+    pub limit: usize,
+    pub path_prefix: Option<&'a Path>,
+}
+
+impl<'a> VectorQuery<'a> {
+    pub fn new(query_vec: &'a [f32]) -> Self {
+        Self {
+            query_vec,
+            limit: 10,
+            path_prefix: None,
+        }
+    }
+
+    pub fn limit(mut self, n: usize) -> Self {
+        self.limit = n;
+        self
+    }
+
+    pub fn path_prefix(mut self, p: &'a Path) -> Self {
+        self.path_prefix = Some(p);
+        self
+    }
+}
+
+/// Hybrid (FTS + vector) search query, merged via Reciprocal Rank Fusion.
+#[derive(Debug, Clone)]
+pub struct HybridQuery<'a> {
+    pub text: &'a str,
+    pub query_vec: &'a [f32],
+    pub limit: usize,
+    pub path_prefix: Option<&'a Path>,
+    pub rrf_k: f64,
+    pub weight_fts: f64,
+    pub weight_sem: f64,
+}
+
+impl<'a> HybridQuery<'a> {
+    pub fn new(text: &'a str, query_vec: &'a [f32]) -> Self {
+        Self {
+            text,
+            query_vec,
+            limit: 10,
+            path_prefix: None,
+            rrf_k: 60.0,
+            weight_fts: 1.0,
+            weight_sem: 1.0,
+        }
+    }
+
+    pub fn limit(mut self, n: usize) -> Self {
+        self.limit = n;
+        self
+    }
+
+    pub fn path_prefix(mut self, p: &'a Path) -> Self {
+        self.path_prefix = Some(p);
+        self
+    }
+
+    pub fn rrf_k(mut self, k: f64) -> Self {
+        self.rrf_k = k;
+        self
+    }
+
+    pub fn weight_fts(mut self, w: f64) -> Self {
+        self.weight_fts = w;
+        self
+    }
+
+    pub fn weight_sem(mut self, w: f64) -> Self {
+        self.weight_sem = w;
+        self
+    }
+}
 
 // ── shared domain types ───────────────────────────────────────────────────────
 
@@ -121,9 +231,9 @@ pub trait RetrieveStore: Send + Sync {
 
     /// Full-text search; returns up to `limit` results ordered by relevance.
     ///
-    /// SQLite mode uses the FTS5 trigram index (substring / CJK aware).
-    /// LanceDB mode uses the ngram tokenizer (better BM25 ranking).
-    fn search_fts(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>>;
+    /// When `q.path_prefix` is set, only documents whose path starts with
+    /// the given prefix are returned.
+    fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<SearchResult>>;
 
     /// Return the IDs of all documents in the database.
     fn document_ids(&self) -> Result<Vec<i64>>;
@@ -150,6 +260,19 @@ pub trait RetrieveStore: Send + Sync {
     /// Find the `limit` most similar chunks to `query_vec`, ordered by
     /// ascending distance.
     ///
+    /// When `q.path_prefix` is set, only chunks belonging to documents
+    /// whose path starts with the given prefix are returned.
+    ///
     /// Returns an empty `Vec` when no vector backend is configured.
-    fn search_similar(&self, query_vec: &[f32], limit: usize) -> Result<Vec<ChunkSearchResult>>;
+    fn search_similar(&self, q: &VectorQuery<'_>) -> Result<Vec<ChunkSearchResult>>;
+
+    /// Hybrid search combining FTS and vector similarity via RRF.
+    ///
+    /// The default implementation calls [`search_fts`](Self::search_fts) and
+    /// [`search_similar`](Self::search_similar), deduplicates chunks, and
+    /// merges via [`crate::db::merge_rrf`]. Backends may override for
+    /// native hybrid support.
+    fn search_hybrid(&self, q: &HybridQuery<'_>) -> Result<Vec<SearchResult>> {
+        crate::db::default_hybrid(self, q)
+    }
 }

--- a/crates/sapphire-retrieve/src/sqlite_store.rs
+++ b/crates/sapphire-retrieve/src/sqlite_store.rs
@@ -2,21 +2,17 @@
 //!
 //! [`SqliteStore`] stores all data in a single SQLite file using:
 //!
-//! - FTS5 trigram index for full-text search (substring / CJK aware).
+//! - FTS5 trigram index over the `chunks` table for full-text search.
 //! - `sqlite-vec` virtual table for approximate nearest-neighbour search.
-//!
-//! The sqlite-vec extension is optional: construct with
-//! [`SqliteStore::new_fts_only`] to get FTS without vector search, or
-//! [`SqliteStore::new_with_vec`] to enable both.
 //!
 //! # Schema
 //!
 //! | table | purpose |
 //! |-------|---------|
 //! | `files` | path + mtime tracking |
-//! | `documents` | full text corpus |
-//! | `documents_fts` | FTS5 trigram index |
-//! | `chunks` | paragraph-level chunks |
+//! | `documents` | id / title / path |
+//! | `chunks` | per-chunk text + source line range |
+//! | `chunks_fts` | FTS5 trigram index over `chunks.text` |
 //! | `chunk_vectors` | sqlite-vec virtual table (optional) |
 //!
 //! The SQLite schema version is stored in `PRAGMA user_version`.
@@ -33,8 +29,10 @@ use crate::{
     chunker::chunk_document,
     embed::Embedder,
     error::{Error, Result},
-    retrieve_store::{Document, FtsQuery, RetrieveStore, SearchResult, VectorQuery},
-    vector_store::{Chunk, ChunkSearchResult, VecInfo, vec_serialize},
+    retrieve_store::{
+        ChunkHit, Document, FileSearchResult, FtsQuery, RetrieveStore, VectorQuery,
+    },
+    vector_store::{Chunk, VecInfo, vec_serialize},
 };
 
 // ── schema ────────────────────────────────────────────────────────────────────
@@ -45,7 +43,8 @@ use crate::{
 /// - 1: initial schema
 /// - 2: sqlite-vec integration
 /// - 3: replace `chunk_index` with `line` + `column` (source positions)
-/// - 4: add index on `documents(path)` for path-prefix filtering
+/// - 4: chunk-level FTS (`chunks_fts`), `line_start`/`line_end`, drop
+///   `documents.body` and `documents_fts`
 pub const SCHEMA_VERSION: i32 = 4;
 
 const SCHEMA: &str = "
@@ -57,29 +56,27 @@ CREATE TABLE IF NOT EXISTS files (
 CREATE TABLE IF NOT EXISTS documents (
     id    INTEGER PRIMARY KEY,
     title TEXT    NOT NULL DEFAULT '',
-    body  TEXT    NOT NULL DEFAULT '',
     path  TEXT    NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_documents_title ON documents(title);
-CREATE INDEX IF NOT EXISTS idx_documents_path ON documents(path);
+CREATE INDEX IF NOT EXISTS idx_documents_path  ON documents(path);
 
-CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
-    title,
-    body,
-    content       = 'documents',
+CREATE TABLE IF NOT EXISTS chunks (
+    id         INTEGER PRIMARY KEY,
+    doc_id     INTEGER NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    line_start INTEGER NOT NULL,
+    line_end   INTEGER NOT NULL,
+    text       TEXT    NOT NULL,
+    UNIQUE (doc_id, line_start)
+);
+CREATE INDEX IF NOT EXISTS idx_chunks_doc_id ON chunks(doc_id);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+    text,
+    content       = 'chunks',
     content_rowid = 'id',
     tokenize      = 'trigram'
 );
-
-CREATE TABLE IF NOT EXISTS chunks (
-    id     INTEGER PRIMARY KEY,
-    doc_id INTEGER NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
-    line   INTEGER NOT NULL,
-    col    INTEGER NOT NULL DEFAULT 0,
-    text   TEXT    NOT NULL,
-    UNIQUE (doc_id, line)
-);
-CREATE INDEX IF NOT EXISTS idx_chunks_doc_id ON chunks(doc_id);
 ";
 
 // ── sqlite-vec extension init ─────────────────────────────────────────────────
@@ -97,30 +94,16 @@ fn init_sqlite_vec_extension() {
 
 // ── SqliteStore ───────────────────────────────────────────────────────────────
 
-/// SQLite-backed retrieve store.
-///
-/// Manages FTS5 full-text search and, optionally, sqlite-vec vector search.
-///
-/// Construct via [`SqliteStore::new_fts_only`] (FTS only) or
-/// [`SqliteStore::new_with_vec`] (FTS + vector search).
 pub struct SqliteStore {
     db_path: PathBuf,
-    /// `None` = FTS only; `Some(dim)` = FTS + sqlite-vec with `dim`-dimensional
-    /// embeddings.
     dim: Option<u32>,
 }
 
 impl SqliteStore {
-    /// Create a FTS-only store (no vector search).
-    ///
-    /// The SQLite file is created lazily on first use.
     pub fn new_fts_only(db_path: PathBuf) -> Self {
         Self { db_path, dim: None }
     }
 
-    /// Create a store with both FTS and sqlite-vec vector search enabled.
-    ///
-    /// Initialises the vector tables immediately.
     pub fn new_with_vec(db_path: PathBuf, embedding_dim: u32) -> Result<Self> {
         init_sqlite_vec_extension();
         let conn = open_or_init(&db_path)?;
@@ -131,8 +114,6 @@ impl SqliteStore {
         })
     }
 
-    /// Return the vector embedding dimension, or `None` if vector search is
-    /// not enabled.
     pub fn dim(&self) -> Option<u32> {
         self.dim
     }
@@ -186,9 +167,8 @@ impl RetrieveStore for SqliteStore {
     fn upsert_document(&self, doc: &Document) -> Result<()> {
         let conn = self.open_conn()?;
         conn.execute(
-            "INSERT OR REPLACE INTO documents (id, title, body, path) \
-             VALUES (?1, ?2, ?3, ?4)",
-            params![doc.id, doc.title, doc.body, doc.path],
+            "INSERT OR REPLACE INTO documents (id, title, path) VALUES (?1, ?2, ?3)",
+            params![doc.id, doc.title, doc.path],
         )?;
         upsert_chunks(&conn, doc, self.dim.is_some())?;
         Ok(())
@@ -197,13 +177,14 @@ impl RetrieveStore for SqliteStore {
     fn remove_document(&self, id: i64) -> Result<()> {
         let conn = self.open_conn()?;
 
-        let fts_data: Option<(String, String)> = conn
-            .query_row(
-                "SELECT title, body FROM documents WHERE id = ?1",
-                [id],
-                |row| Ok((row.get(0)?, row.get(1)?)),
-            )
-            .ok();
+        // Capture chunk rows for incremental FTS delete before we cascade.
+        let stale_chunks: Vec<(i64, String)> = {
+            let mut stmt = conn.prepare("SELECT id, text FROM chunks WHERE doc_id = ?1")?;
+            stmt.query_map([id], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+        };
 
         if self.dim.is_some() {
             conn.execute(
@@ -215,11 +196,10 @@ impl RetrieveStore for SqliteStore {
 
         conn.execute("DELETE FROM documents WHERE id = ?1", [id])?;
 
-        if let Some((title, body)) = fts_data {
+        for (cid, text) in stale_chunks {
             let _ = conn.execute(
-                "INSERT INTO documents_fts(documents_fts, rowid, title, body) \
-                 VALUES('delete', ?1, ?2, ?3)",
-                params![id, title, body],
+                "INSERT INTO chunks_fts(chunks_fts, rowid, text) VALUES('delete', ?1, ?2)",
+                params![cid, text],
             );
         }
 
@@ -228,51 +208,42 @@ impl RetrieveStore for SqliteStore {
 
     fn rebuild_fts(&self) -> Result<()> {
         let conn = self.open_conn()?;
-        conn.execute_batch("INSERT INTO documents_fts(documents_fts) VALUES('rebuild')")?;
+        conn.execute_batch("INSERT INTO chunks_fts(chunks_fts) VALUES('rebuild')")?;
         Ok(())
     }
 
-    fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<SearchResult>> {
+    fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<FileSearchResult>> {
         let conn = self.open_conn()?;
+        let over_fetch = (q.limit * 5) as i64;
         let prefix_glob = q.path_prefix.map(|p| format!("{}*", p.to_string_lossy()));
         let sql = if prefix_glob.is_some() {
-            "SELECT d.id, d.title, d.path, fts.rank
-             FROM documents_fts fts
-             JOIN documents d ON d.id = fts.rowid
-             WHERE documents_fts MATCH ?1 AND d.path GLOB ?3
+            "SELECT c.doc_id, d.title, d.path, c.line_start, c.line_end, c.text, fts.rank
+             FROM chunks_fts fts
+             JOIN chunks c    ON c.id = fts.rowid
+             JOIN documents d ON d.id = c.doc_id
+             WHERE chunks_fts MATCH ?1 AND d.path GLOB ?3
              ORDER BY fts.rank
              LIMIT ?2"
         } else {
-            "SELECT d.id, d.title, d.path, fts.rank
-             FROM documents_fts fts
-             JOIN documents d ON d.id = fts.rowid
-             WHERE documents_fts MATCH ?1
+            "SELECT c.doc_id, d.title, d.path, c.line_start, c.line_end, c.text, fts.rank
+             FROM chunks_fts fts
+             JOIN chunks c    ON c.id = fts.rowid
+             JOIN documents d ON d.id = c.doc_id
+             WHERE chunks_fts MATCH ?1
              ORDER BY fts.rank
              LIMIT ?2"
         };
         let mut stmt = conn.prepare(sql)?;
-        let results = if let Some(ref glob) = prefix_glob {
-            stmt.query_map(params![q.query, q.limit as i64, glob], |row| {
-                Ok(SearchResult {
-                    id: row.get::<_, i64>(0)?,
-                    title: row.get::<_, String>(1)?,
-                    path: row.get::<_, String>(2)?,
-                    score: row.get::<_, f64>(3).unwrap_or(0.0),
-                })
-            })?
-            .collect::<rusqlite::Result<Vec<_>>>()?
+        let rows: Vec<ChunkRow> = if let Some(ref glob) = prefix_glob {
+            stmt.query_map(params![q.query, over_fetch, glob], map_chunk_row)?
+                .collect::<rusqlite::Result<Vec<_>>>()?
         } else {
-            stmt.query_map(params![q.query, q.limit as i64], |row| {
-                Ok(SearchResult {
-                    id: row.get::<_, i64>(0)?,
-                    title: row.get::<_, String>(1)?,
-                    path: row.get::<_, String>(2)?,
-                    score: row.get::<_, f64>(3).unwrap_or(0.0),
-                })
-            })?
-            .collect::<rusqlite::Result<Vec<_>>>()?
+            stmt.query_map(params![q.query, over_fetch], map_chunk_row)?
+                .collect::<rusqlite::Result<Vec<_>>>()?
         };
-        Ok(results)
+
+        // FTS rank is negative; more-negative = more relevant.  Lower score wins.
+        Ok(group_by_file(rows, q.limit, |a, b| a < b))
     }
 
     fn document_ids(&self) -> Result<Vec<i64>> {
@@ -344,51 +315,44 @@ impl RetrieveStore for SqliteStore {
         })
     }
 
-    fn search_similar(&self, q: &VectorQuery<'_>) -> Result<Vec<ChunkSearchResult>> {
+    fn search_similar(&self, q: &VectorQuery<'_>) -> Result<Vec<FileSearchResult>> {
         if self.dim.is_none() {
             return Ok(Vec::new());
         }
         let conn = self.open_conn()?;
-        let blob = vec_serialize(q.query_vec);
 
-        // sqlite-vec doesn't support WHERE filters on the virtual table join
-        // directly, so we over-fetch and post-filter when a path prefix is given.
-        let over_fetch = if q.path_prefix.is_some() {
-            q.limit * 5
-        } else {
-            q.limit
-        };
+        // Embed query text.
+        let query_vecs = q.embedder.embed_texts(&[q.query])?;
+        let query_vec = query_vecs
+            .into_iter()
+            .next()
+            .ok_or_else(|| Error::Embed("embedder returned empty result".into()))?;
+        let blob = vec_serialize(&query_vec);
+
+        // Over-fetch so grouping + path-prefix filtering doesn't starve us.
+        let over_fetch = (q.limit * 5) as i64;
 
         let mut stmt = conn.prepare(
-            "SELECT d.id, d.title, d.path, c.line, c.col, c.text, cv.distance
+            "SELECT d.id, d.title, d.path, c.line_start, c.line_end, c.text, cv.distance
              FROM chunk_vectors cv
-             JOIN chunks c ON c.id = cv.chunk_id
+             JOIN chunks c    ON c.id = cv.chunk_id
              JOIN documents d ON d.id = c.doc_id
              WHERE cv.embedding MATCH ?1 AND k = ?2
              ORDER BY cv.distance",
         )?;
         let prefix = q.path_prefix.map(|p| p.to_string_lossy().to_string());
-        let results: Vec<ChunkSearchResult> = stmt
-            .query_map(params![blob, over_fetch as i64], |row| {
-                Ok(ChunkSearchResult {
-                    doc_id: row.get::<_, i64>(0)?,
-                    doc_title: row.get::<_, String>(1)?,
-                    doc_path: row.get::<_, String>(2)?,
-                    line: row.get::<_, i64>(3)? as usize,
-                    column: row.get::<_, i64>(4)? as usize,
-                    chunk_text: row.get::<_, String>(5)?,
-                    score: row.get::<_, f64>(6).unwrap_or(0.0),
-                })
-            })?
+        let rows: Vec<ChunkRow> = stmt
+            .query_map(params![blob, over_fetch], map_chunk_row)?
             .filter_map(|r| r.ok())
             .filter(|r| {
                 prefix
                     .as_ref()
-                    .map_or(true, |pfx| r.doc_path.starts_with(pfx.as_str()))
+                    .map_or(true, |pfx| r.path.starts_with(pfx.as_str()))
             })
-            .take(q.limit)
             .collect();
-        Ok(results)
+
+        // Vector distance: lower = better.
+        Ok(group_by_file(rows, q.limit, |a, b| a < b))
     }
 }
 
@@ -398,6 +362,20 @@ pub(crate) fn open_or_init(db_path: &Path) -> Result<Connection> {
     if let Some(parent) = db_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
+
+    // Check for existing DB version first.  If it pre-dates the current
+    // schema, wipe-and-recreate (SCHEMA_VERSION 4 is a hard break: old
+    // `documents.body` / `documents_fts` / `chunks.line` layouts are
+    // incompatible with the new chunk-level FTS design).
+    let db_version: i32 = {
+        let conn = Connection::open(db_path)?;
+        conn.query_row("PRAGMA user_version", [], |row| row.get(0))?
+    };
+
+    if db_version != 0 && db_version < SCHEMA_VERSION {
+        wipe_db_files(db_path);
+    }
+
     let conn = Connection::open(db_path)?;
     conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
 
@@ -413,23 +391,10 @@ pub(crate) fn open_or_init(db_path: &Path) -> Result<Connection> {
         return Ok(conn);
     }
 
-    if db_version < SCHEMA_VERSION {
-        apply_migrations(&conn, db_version)?;
-        conn.execute_batch(&format!("PRAGMA user_version = {SCHEMA_VERSION}"))?;
-        return Ok(conn);
-    }
-
     Err(Error::SchemaTooNew {
         db_version,
         app_version: SCHEMA_VERSION,
     })
-}
-
-fn apply_migrations(conn: &Connection, from_version: i32) -> Result<()> {
-    if from_version < 4 {
-        conn.execute_batch("CREATE INDEX IF NOT EXISTS idx_documents_path ON documents(path)")?;
-    }
-    Ok(())
 }
 
 pub fn wipe_db_files(db_path: &Path) {
@@ -492,15 +457,89 @@ fn ensure_vec_tables(conn: &Connection, dim: u32) -> Result<()> {
     Ok(())
 }
 
+// ── chunk row / grouping helpers ─────────────────────────────────────────────
+
+struct ChunkRow {
+    doc_id: i64,
+    title: String,
+    path: String,
+    line_start: usize,
+    line_end: usize,
+    text: String,
+    score: f64,
+}
+
+fn map_chunk_row(row: &rusqlite::Row) -> rusqlite::Result<ChunkRow> {
+    Ok(ChunkRow {
+        doc_id: row.get::<_, i64>(0)?,
+        title: row.get::<_, String>(1)?,
+        path: row.get::<_, String>(2)?,
+        line_start: row.get::<_, i64>(3)? as usize,
+        line_end: row.get::<_, i64>(4)? as usize,
+        text: row.get::<_, String>(5)?,
+        score: row.get::<_, f64>(6).unwrap_or(0.0),
+    })
+}
+
+/// Group chunk-level rows by `doc_id` into `FileSearchResult`s.
+///
+/// `is_better(a, b)` returns true when score `a` is better than `b` (used
+/// both for picking the representative score and for sorting files).  The
+/// chunks within each file are sorted by the same comparator.
+fn group_by_file<F>(rows: Vec<ChunkRow>, limit: usize, is_better: F) -> Vec<FileSearchResult>
+where
+    F: Fn(f64, f64) -> bool + Copy,
+{
+    let mut by_doc: HashMap<i64, FileSearchResult> = HashMap::new();
+
+    for r in rows {
+        let entry = by_doc.entry(r.doc_id).or_insert_with(|| FileSearchResult {
+            id: r.doc_id,
+            title: r.title.clone(),
+            path: r.path.clone(),
+            score: r.score,
+            chunks: Vec::new(),
+        });
+        if is_better(r.score, entry.score) {
+            entry.score = r.score;
+        }
+        entry.chunks.push(ChunkHit {
+            line_start: r.line_start,
+            line_end: r.line_end,
+            text: r.text,
+            score: r.score,
+        });
+    }
+
+    let mut files: Vec<FileSearchResult> = by_doc.into_values().collect();
+    for f in &mut files {
+        f.chunks.sort_by(|a, b| {
+            if is_better(a.score, b.score) {
+                std::cmp::Ordering::Less
+            } else if is_better(b.score, a.score) {
+                std::cmp::Ordering::Greater
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        });
+    }
+    files.sort_by(|a, b| {
+        if is_better(a.score, b.score) {
+            std::cmp::Ordering::Less
+        } else if is_better(b.score, a.score) {
+            std::cmp::Ordering::Greater
+        } else {
+            std::cmp::Ordering::Equal
+        }
+    });
+    files.truncate(limit);
+    files
+}
+
 // ── chunk helpers ─────────────────────────────────────────────────────────────
 
 fn upsert_chunks(conn: &Connection, doc: &Document, has_vec: bool) -> Result<()> {
-    // Build the list of (line, col, embed_text) tuples.
-    //
-    // When the caller provides pre-computed chunks (e.g. from JsonChunker),
-    // `line` is the 0-based source line number and `col` is the byte column.
-    // Otherwise we fall back to chunk_document() with sequential line=0,1,2,…
-    // and col=0.
+    // Build (line_start, line_end, embed_text) tuples.
     let computed: Vec<(usize, usize, String)>;
     let chunks: &[(usize, usize, String)] = if let Some(ref c) = doc.chunks {
         c.as_slice()
@@ -508,51 +547,100 @@ fn upsert_chunks(conn: &Connection, doc: &Document, has_vec: bool) -> Result<()>
         computed = chunk_document(&doc.title, &doc.body)
             .into_iter()
             .enumerate()
-            .map(|(i, t)| (i, 0usize, t))
+            .map(|(i, t)| (i, i, t))
             .collect();
         &computed
     };
 
-    let live_lines: std::collections::HashSet<i64> =
-        chunks.iter().map(|(line, _, _)| *line as i64).collect();
+    let live_starts: HashSet<i64> = chunks
+        .iter()
+        .map(|(start, _, _)| *start as i64)
+        .collect();
 
-    // Delete stale chunks (those no longer present in the new set).
-    let old_lines: Vec<i64> = {
-        let mut stmt = conn.prepare("SELECT line FROM chunks WHERE doc_id = ?1")?;
-        stmt.query_map([doc.id], |row| row.get::<_, i64>(0))?
-            .filter_map(|r| r.ok())
-            .filter(|l| !live_lines.contains(l))
-            .collect()
+    // Delete stale chunks (FTS5 external-content: need to insert 'delete' rows
+    // before dropping the underlying row, or rebuild the index after).
+    let old_rows: Vec<(i64, i64, String)> = {
+        let mut stmt = conn.prepare(
+            "SELECT id, line_start, text FROM chunks WHERE doc_id = ?1",
+        )?;
+        stmt.query_map([doc.id], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })?
+        .filter_map(|r| r.ok())
+        .filter(|(_, s, _)| !live_starts.contains(s))
+        .collect()
     };
-    for line in old_lines {
+    for (cid, start, old_text) in old_rows {
         if has_vec {
-            conn.execute(
-                "DELETE FROM chunk_vectors WHERE chunk_id = \
-                 (SELECT id FROM chunks WHERE doc_id = ?1 AND line = ?2)",
-                params![doc.id, line],
-            )?;
+            conn.execute("DELETE FROM chunk_vectors WHERE chunk_id = ?1", [cid])?;
         }
+        let _ = conn.execute(
+            "INSERT INTO chunks_fts(chunks_fts, rowid, text) VALUES('delete', ?1, ?2)",
+            params![cid, old_text],
+        );
         conn.execute(
-            "DELETE FROM chunks WHERE doc_id = ?1 AND line = ?2",
-            params![doc.id, line],
+            "DELETE FROM chunks WHERE doc_id = ?1 AND line_start = ?2",
+            params![doc.id, start],
         )?;
     }
 
-    // Upsert each chunk; if text changed, invalidate the stale embedding.
-    for (line, col, text) in chunks {
+    // Upsert each live chunk; if text changed, invalidate the stale embedding
+    // and update the FTS index.
+    for (line_start, line_end, text) in chunks {
+        // Fetch previous row (if any) for FTS incremental delete.
+        let prev: Option<(i64, String)> = conn
+            .query_row(
+                "SELECT id, text FROM chunks WHERE doc_id = ?1 AND line_start = ?2",
+                params![doc.id, *line_start as i64],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+            )
+            .ok();
+
         conn.execute(
-            "INSERT INTO chunks (doc_id, line, col, text) VALUES (?1, ?2, ?3, ?4)
-             ON CONFLICT(doc_id, line) DO UPDATE
-             SET col = excluded.col, text = excluded.text
-             WHERE text != excluded.text",
-            params![doc.id, *line as i64, *col as i64, text],
+            "INSERT INTO chunks (doc_id, line_start, line_end, text)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(doc_id, line_start) DO UPDATE
+             SET line_end = excluded.line_end,
+                 text     = excluded.text
+             WHERE text != excluded.text OR line_end != excluded.line_end",
+            params![doc.id, *line_start as i64, *line_end as i64, text],
         )?;
-        if has_vec && conn.changes() > 0 {
-            conn.execute(
-                "DELETE FROM chunk_vectors WHERE chunk_id = \
-                 (SELECT id FROM chunks WHERE doc_id = ?1 AND line = ?2)",
-                params![doc.id, *line as i64],
-            )?;
+
+        let new_id: Option<i64> = conn
+            .query_row(
+                "SELECT id FROM chunks WHERE doc_id = ?1 AND line_start = ?2",
+                params![doc.id, *line_start as i64],
+                |row| row.get(0),
+            )
+            .ok();
+
+        match (prev, new_id) {
+            (Some((pid, old_text)), Some(nid)) if pid == nid && old_text != *text => {
+                // Existing row, text changed: refresh FTS + drop stale vector.
+                let _ = conn.execute(
+                    "INSERT INTO chunks_fts(chunks_fts, rowid, text) VALUES('delete', ?1, ?2)",
+                    params![pid, old_text],
+                );
+                let _ = conn.execute(
+                    "INSERT INTO chunks_fts(rowid, text) VALUES (?1, ?2)",
+                    params![nid, text],
+                );
+                if has_vec {
+                    conn.execute("DELETE FROM chunk_vectors WHERE chunk_id = ?1", [nid])?;
+                }
+            }
+            (None, Some(nid)) => {
+                // New row: add to FTS.
+                let _ = conn.execute(
+                    "INSERT INTO chunks_fts(rowid, text) VALUES (?1, ?2)",
+                    params![nid, text],
+                );
+            }
+            _ => {}
         }
     }
     Ok(())
@@ -562,7 +650,7 @@ fn upsert_chunks(conn: &Connection, doc: &Document, has_vec: bool) -> Result<()>
 
 fn sqlite_vec_embedded_keys(conn: &Connection) -> Result<HashSet<(i64, usize)>> {
     let mut stmt = conn.prepare(
-        "SELECT c.doc_id, c.line
+        "SELECT c.doc_id, c.line_start
          FROM chunks c
          JOIN chunk_vectors cv ON cv.chunk_id = c.id",
     )?;
@@ -580,7 +668,7 @@ fn collect_pending_chunks(
     embedded_keys: &HashSet<(i64, usize)>,
 ) -> Result<Vec<Chunk>> {
     let mut stmt = conn.prepare(
-        "SELECT c.doc_id, c.line, c.col, c.text, d.title, d.path
+        "SELECT c.doc_id, c.line_start, c.line_end, c.text, d.title, d.path
          FROM chunks c
          JOIN documents d ON d.id = c.doc_id",
     )?;
@@ -588,15 +676,15 @@ fn collect_pending_chunks(
         .query_map([], |row| {
             Ok(Chunk {
                 doc_id: row.get::<_, i64>(0)?,
-                line: row.get::<_, i64>(1)? as usize,
-                column: row.get::<_, i64>(2)? as usize,
+                line_start: row.get::<_, i64>(1)? as usize,
+                line_end: row.get::<_, i64>(2)? as usize,
                 text: row.get::<_, String>(3)?,
                 doc_title: row.get::<_, String>(4)?,
                 doc_path: row.get::<_, String>(5)?,
             })
         })?
         .filter_map(|r| r.ok())
-        .filter(|c| !embedded_keys.contains(&(c.doc_id, c.line)))
+        .filter(|c| !embedded_keys.contains(&(c.doc_id, c.line_start)))
         .collect();
     Ok(chunks)
 }
@@ -609,8 +697,8 @@ fn sqlite_vec_insert_embeddings(
     for (chunk, emb) in chunks.iter().zip(embeddings) {
         let chunk_id: Option<i64> = conn
             .query_row(
-                "SELECT id FROM chunks WHERE doc_id = ?1 AND line = ?2",
-                params![chunk.doc_id, chunk.line as i64],
+                "SELECT id FROM chunks WHERE doc_id = ?1 AND line_start = ?2",
+                params![chunk.doc_id, chunk.line_start as i64],
                 |row| row.get(0),
             )
             .ok();

--- a/crates/sapphire-retrieve/src/sqlite_store.rs
+++ b/crates/sapphire-retrieve/src/sqlite_store.rs
@@ -33,7 +33,7 @@ use crate::{
     chunker::chunk_document,
     embed::Embedder,
     error::{Error, Result},
-    retrieve_store::{Document, RetrieveStore, SearchResult},
+    retrieve_store::{Document, FtsQuery, RetrieveStore, SearchResult, VectorQuery},
     vector_store::{Chunk, ChunkSearchResult, VecInfo, vec_serialize},
 };
 
@@ -45,7 +45,8 @@ use crate::{
 /// - 1: initial schema
 /// - 2: sqlite-vec integration
 /// - 3: replace `chunk_index` with `line` + `column` (source positions)
-pub const SCHEMA_VERSION: i32 = 3;
+/// - 4: add index on `documents(path)` for path-prefix filtering
+pub const SCHEMA_VERSION: i32 = 4;
 
 const SCHEMA: &str = "
 CREATE TABLE IF NOT EXISTS files (
@@ -60,6 +61,7 @@ CREATE TABLE IF NOT EXISTS documents (
     path  TEXT    NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_documents_title ON documents(title);
+CREATE INDEX IF NOT EXISTS idx_documents_path ON documents(path);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
     title,
@@ -230,18 +232,27 @@ impl RetrieveStore for SqliteStore {
         Ok(())
     }
 
-    fn search_fts(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
+    fn search_fts(&self, q: &FtsQuery<'_>) -> Result<Vec<SearchResult>> {
         let conn = self.open_conn()?;
-        let mut stmt = conn.prepare(
+        let prefix_glob = q.path_prefix.map(|p| format!("{}*", p.to_string_lossy()));
+        let sql = if prefix_glob.is_some() {
+            "SELECT d.id, d.title, d.path, fts.rank
+             FROM documents_fts fts
+             JOIN documents d ON d.id = fts.rowid
+             WHERE documents_fts MATCH ?1 AND d.path GLOB ?3
+             ORDER BY fts.rank
+             LIMIT ?2"
+        } else {
             "SELECT d.id, d.title, d.path, fts.rank
              FROM documents_fts fts
              JOIN documents d ON d.id = fts.rowid
              WHERE documents_fts MATCH ?1
              ORDER BY fts.rank
-             LIMIT ?2",
-        )?;
-        let results = stmt
-            .query_map(params![query, limit as i64], |row| {
+             LIMIT ?2"
+        };
+        let mut stmt = conn.prepare(sql)?;
+        let results = if let Some(ref glob) = prefix_glob {
+            stmt.query_map(params![q.query, q.limit as i64, glob], |row| {
                 Ok(SearchResult {
                     id: row.get::<_, i64>(0)?,
                     title: row.get::<_, String>(1)?,
@@ -249,7 +260,18 @@ impl RetrieveStore for SqliteStore {
                     score: row.get::<_, f64>(3).unwrap_or(0.0),
                 })
             })?
-            .collect::<rusqlite::Result<Vec<_>>>()?;
+            .collect::<rusqlite::Result<Vec<_>>>()?
+        } else {
+            stmt.query_map(params![q.query, q.limit as i64], |row| {
+                Ok(SearchResult {
+                    id: row.get::<_, i64>(0)?,
+                    title: row.get::<_, String>(1)?,
+                    path: row.get::<_, String>(2)?,
+                    score: row.get::<_, f64>(3).unwrap_or(0.0),
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+        };
         Ok(results)
     }
 
@@ -322,12 +344,21 @@ impl RetrieveStore for SqliteStore {
         })
     }
 
-    fn search_similar(&self, query_vec: &[f32], limit: usize) -> Result<Vec<ChunkSearchResult>> {
+    fn search_similar(&self, q: &VectorQuery<'_>) -> Result<Vec<ChunkSearchResult>> {
         if self.dim.is_none() {
             return Ok(Vec::new());
         }
         let conn = self.open_conn()?;
-        let blob = vec_serialize(query_vec);
+        let blob = vec_serialize(q.query_vec);
+
+        // sqlite-vec doesn't support WHERE filters on the virtual table join
+        // directly, so we over-fetch and post-filter when a path prefix is given.
+        let over_fetch = if q.path_prefix.is_some() {
+            q.limit * 5
+        } else {
+            q.limit
+        };
+
         let mut stmt = conn.prepare(
             "SELECT d.id, d.title, d.path, c.line, c.col, c.text, cv.distance
              FROM chunk_vectors cv
@@ -336,8 +367,9 @@ impl RetrieveStore for SqliteStore {
              WHERE cv.embedding MATCH ?1 AND k = ?2
              ORDER BY cv.distance",
         )?;
-        let results = stmt
-            .query_map(params![blob, limit as i64], |row| {
+        let prefix = q.path_prefix.map(|p| p.to_string_lossy().to_string());
+        let results: Vec<ChunkSearchResult> = stmt
+            .query_map(params![blob, over_fetch as i64], |row| {
                 Ok(ChunkSearchResult {
                     doc_id: row.get::<_, i64>(0)?,
                     doc_title: row.get::<_, String>(1)?,
@@ -348,7 +380,14 @@ impl RetrieveStore for SqliteStore {
                     score: row.get::<_, f64>(6).unwrap_or(0.0),
                 })
             })?
-            .collect::<rusqlite::Result<Vec<_>>>()?;
+            .filter_map(|r| r.ok())
+            .filter(|r| {
+                prefix
+                    .as_ref()
+                    .map_or(true, |pfx| r.doc_path.starts_with(pfx.as_str()))
+            })
+            .take(q.limit)
+            .collect();
         Ok(results)
     }
 }
@@ -374,10 +413,23 @@ pub(crate) fn open_or_init(db_path: &Path) -> Result<Connection> {
         return Ok(conn);
     }
 
+    if db_version < SCHEMA_VERSION {
+        apply_migrations(&conn, db_version)?;
+        conn.execute_batch(&format!("PRAGMA user_version = {SCHEMA_VERSION}"))?;
+        return Ok(conn);
+    }
+
     Err(Error::SchemaTooNew {
         db_version,
         app_version: SCHEMA_VERSION,
     })
+}
+
+fn apply_migrations(conn: &Connection, from_version: i32) -> Result<()> {
+    if from_version < 4 {
+        conn.execute_batch("CREATE INDEX IF NOT EXISTS idx_documents_path ON documents(path)")?;
+    }
+    Ok(())
 }
 
 pub fn wipe_db_files(db_path: &Path) {

--- a/crates/sapphire-retrieve/src/vector_store.rs
+++ b/crates/sapphire-retrieve/src/vector_store.rs
@@ -1,21 +1,4 @@
-//! Vector store abstraction.
-//!
-//! [`VectorStore`] is a **synchronous** trait used internally by the SQLite vec
-//! backend of [`crate::db::RetrieveDb`].  The LanceDB full backend
-//! (`lancedb_store`) does not use this trait.
-//!
-//! # Chunk identity
-//!
-//! Each chunk is identified by the pair `(doc_id, line)`.  `doc_id` is a
-//! stable i64 assigned by the caller (e.g. a path hash or application-level ID).
-//! `line` is the 0-based source line number of the chunk's first character in
-//! the original file, as produced by the [`Chunker`](crate::chunker::Chunker)
-//! trait.  This value is stored verbatim in the database so that search results
-//! carry a navigable source position with no extra lookup.
-
-use std::collections::HashSet;
-
-use crate::error::Result;
+//! Internal vector-store types shared by the SQLite and LanceDB backends.
 
 // ── public types ──────────────────────────────────────────────────────────────
 
@@ -24,35 +7,16 @@ use crate::error::Result;
 pub struct Chunk {
     /// Stable document ID assigned by the caller.
     pub doc_id: i64,
-    /// Zero-based source line number where this chunk begins.
-    pub line: usize,
-    /// Zero-based byte column within `line` where this chunk begins.
-    pub column: usize,
+    /// First source line of this chunk (inclusive, 0-based).
+    pub line_start: usize,
+    /// Last source line of this chunk (inclusive, 0-based).
+    pub line_end: usize,
     /// Embeddable text: title prepended to the extracted chunk body.
     pub text: String,
     /// Denormalised document title (for display in search results).
     pub doc_title: String,
     /// Denormalised absolute file path (for display in search results).
     pub doc_path: String,
-}
-
-/// A result returned by [`VectorStore::search_similar`].
-#[derive(Debug, Clone)]
-pub struct ChunkSearchResult {
-    pub doc_id: i64,
-    pub doc_title: String,
-    pub doc_path: String,
-    /// Zero-based source line number of the matching chunk in the original file.
-    ///
-    /// A GUI can use this value directly to navigate to the exact location in
-    /// the source file and render surrounding context.
-    pub line: usize,
-    /// Zero-based byte column within `line` where the matching chunk begins.
-    pub column: usize,
-    /// The text of the matching chunk.
-    pub chunk_text: String,
-    /// L2 distance (lower = more similar).
-    pub score: f64,
 }
 
 /// Statistics about the vector index.
@@ -63,27 +27,6 @@ pub struct VecInfo {
     pub vector_count: u64,
     /// Number of chunks that do not yet have an embedding.
     pub pending_count: u64,
-}
-
-// ── trait ─────────────────────────────────────────────────────────────────────
-
-/// Abstraction over a vector storage backend.
-///
-/// All methods are **synchronous**.  Backends that are inherently async
-/// (e.g. LanceDB) wrap their async operations in an internal Tokio runtime.
-pub trait VectorStore {
-    /// Return the `(doc_id, line)` pairs that already have embeddings stored,
-    /// so callers can compute the pending set.
-    fn embedded_chunk_keys(&self) -> Result<HashSet<(i64, usize)>>;
-
-    /// Store embeddings for a batch of chunks.
-    ///
-    /// `chunks` and `embeddings` are parallel slices of equal length.
-    fn insert_embeddings(&self, chunks: &[Chunk], embeddings: &[Vec<f32>]) -> Result<()>;
-
-    /// Find the `limit` most similar chunks to `query_vec`, ordered by
-    /// ascending distance.
-    fn search_similar(&self, query_vec: &[f32], limit: usize) -> Result<Vec<ChunkSearchResult>>;
 }
 
 // ── internal helpers shared by db.rs and lancedb_store.rs ─────────────────────

--- a/crates/sapphire-workspace-cli/src/mcp.rs
+++ b/crates/sapphire-workspace-cli/src/mcp.rs
@@ -10,7 +10,7 @@ use rmcp::{
     schemars, tool, tool_handler, tool_router,
     transport::stdio,
 };
-use sapphire_workspace::{FtsQuery, VectorQuery, Workspace, WorkspaceState, dedup_chunk_results};
+use sapphire_workspace::{HybridQuery, Workspace, WorkspaceState};
 
 use crate::config::UserConfig;
 
@@ -137,18 +137,19 @@ impl RecallServer {
         .map_err(|e| e.to_string())
     }
 
-    #[tool(description = "Search indexed documents. \
-        When `embedding.enabled = true` in the user config, uses approximate \
-        (vector/semantic) search. Otherwise falls back to full-text search \
-        (FTS5 trigram index, supports substring and CJK queries). \
-        Returns a JSON array of results ordered by relevance, each with \
-        `id`, `title`, `path`, and `score`.")]
+    #[tool(description = "Search indexed documents using hybrid (FTS + vector) search. \
+        When an embedder is configured, merges full-text and semantic search via \
+        Reciprocal Rank Fusion; otherwise falls back to FTS-only. \
+        Returns a JSON array of files ordered by relevance, each with \
+        `id`, `title`, `path`, `score`, and a `chunks` array giving the matched \
+        line ranges (`line_start`, `line_end`) and text within each file.")]
     fn search(&self, Parameters(p): Parameters<SearchParams>) -> Result<String, String> {
         (|| -> anyhow::Result<String> {
             self.with_state(|s| {
                 s.sync()?;
                 let limit = p.limit.unwrap_or(10);
 
+                // Opportunistically embed a small backlog before searching.
                 if let Some(embedder) = s.embedder() {
                     let pending = s
                         .retrieve_db()
@@ -158,25 +159,16 @@ impl RecallServer {
                     if pending > 0 && pending <= 50 {
                         let _ = s.retrieve_db().embed_pending(embedder, &|_, _| {});
                     }
-
-                    let query_vecs = embedder.embed_texts(&[p.query.as_str()])?;
-                    let query_vec = query_vecs
-                        .into_iter()
-                        .next()
-                        .ok_or_else(|| anyhow::anyhow!("embedder returned empty result"))?;
-                    let vq = VectorQuery::new(&query_vec).limit(limit * 3);
-                    let raw = s
-                        .retrieve_db()
-                        .search_similar(&vq)
-                        .map_err(anyhow::Error::msg)?;
-                    let results = dedup_chunk_results(raw, limit);
-                    return Ok(serde_json::to_string_pretty(&results)?);
                 }
 
-                let fq = FtsQuery::new(&p.query).limit(limit);
+                let mut hq = HybridQuery::new(p.query.as_str()).limit(limit);
+                if let Some(e) = s.embedder() {
+                    hq = hq.embedder(e);
+                }
+
                 let results = s
                     .retrieve_db()
-                    .search_fts(&fq)
+                    .search_hybrid(&hq)
                     .map_err(anyhow::Error::msg)?;
                 Ok(serde_json::to_string_pretty(&results)?)
             })

--- a/crates/sapphire-workspace-cli/src/mcp.rs
+++ b/crates/sapphire-workspace-cli/src/mcp.rs
@@ -10,7 +10,7 @@ use rmcp::{
     schemars, tool, tool_handler, tool_router,
     transport::stdio,
 };
-use sapphire_workspace::{Workspace, WorkspaceState, dedup_chunk_results};
+use sapphire_workspace::{FtsQuery, VectorQuery, Workspace, WorkspaceState, dedup_chunk_results};
 
 use crate::config::UserConfig;
 
@@ -164,17 +164,19 @@ impl RecallServer {
                         .into_iter()
                         .next()
                         .ok_or_else(|| anyhow::anyhow!("embedder returned empty result"))?;
+                    let vq = VectorQuery::new(&query_vec).limit(limit * 3);
                     let raw = s
                         .retrieve_db()
-                        .search_similar(&query_vec, limit * 3)
+                        .search_similar(&vq)
                         .map_err(anyhow::Error::msg)?;
                     let results = dedup_chunk_results(raw, limit);
                     return Ok(serde_json::to_string_pretty(&results)?);
                 }
 
+                let fq = FtsQuery::new(&p.query).limit(limit);
                 let results = s
                     .retrieve_db()
-                    .search_fts(&p.query, limit)
+                    .search_fts(&fq)
                     .map_err(anyhow::Error::msg)?;
                 Ok(serde_json::to_string_pretty(&results)?)
             })

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -37,16 +37,11 @@ pub fn path_to_doc_id(path: &Path) -> i64 {
 ///
 /// # Supported file types
 ///
-/// | Extension | Chunking | `line` in results |
-/// |-----------|----------|-------------------|
-/// | `md`, `markdown`, `txt`, `rst`, `org` | paragraph split | paragraph start line |
-/// | `json` | message/element extraction | source line of element `{` |
-/// | `jsonl` | one message per line | line index |
-///
-/// For JSON/JSONL files the body stored in the database is extracted message
-/// text (no JSON syntax noise), and each chunk's `line` value in
-/// [`ChunkSearchResult`](sapphire_retrieve::ChunkSearchResult) is the 0-based
-/// source line number of that message in the original file.
+/// | Extension | Chunking | line range in results |
+/// |-----------|----------|-----------------------|
+/// | `md`, `markdown`, `txt`, `rst`, `org` | paragraph split | start/end line of paragraph |
+/// | `json` | message/element extraction | source line range of element |
+/// | `jsonl` | one message per line | `line_start == line_end` |
 pub fn sync_workspace(
     workspace: &Workspace,
     retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
@@ -120,7 +115,7 @@ pub fn sync_workspace(
                     } else {
                         format!("{title}\n\n{}", c.text)
                     };
-                    (c.line, c.column, embed)
+                    (c.line_start, c.line_end, embed)
                 })
                 .collect();
             Document {
@@ -251,7 +246,7 @@ pub fn sync_workspace_incremental(
                     } else {
                         format!("{title}\n\n{}", c.text)
                     };
-                    (c.line, c.column, embed)
+                    (c.line_start, c.line_end, embed)
                 })
                 .collect();
             Document {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,13 +23,10 @@ pub use sapphire_retrieve::db::SCHEMA_VERSION as RETRIEVE_SCHEMA_VERSION;
 #[cfg(feature = "lancedb-store")]
 pub use sapphire_retrieve::lancedb_store;
 pub use sapphire_retrieve::{
-    Chunk, ChunkSearchResult, Document, Embedder, EmbedderConfig, Error as RetrieveError,
-    FtsQuery, HybridQuery, RetrieveStore, SearchResult, VecInfo, VectorQuery, build_embedder,
-    dedup_chunk_results, merge_rrf,
+    Chunk, ChunkHit, Document, Embedder, EmbedderConfig, Error as RetrieveError, FileSearchResult,
+    FtsQuery, HybridQuery, RetrieveDb, RetrieveStore, VecInfo, VectorQuery, build_embedder,
+    default_hybrid, merge_rrf_files,
 };
-// RetrieveDb is kept for backwards compatibility; prefer RetrieveStore + factory functions.
-#[allow(deprecated)]
-pub use sapphire_retrieve::RetrieveDb;
 
 // Re-export sapphire-sync public API.
 #[cfg(feature = "git-sync")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,8 @@ pub use sapphire_retrieve::db::SCHEMA_VERSION as RETRIEVE_SCHEMA_VERSION;
 pub use sapphire_retrieve::lancedb_store;
 pub use sapphire_retrieve::{
     Chunk, ChunkSearchResult, Document, Embedder, EmbedderConfig, Error as RetrieveError,
-    RetrieveStore, SearchResult, VecInfo, build_embedder, dedup_chunk_results,
+    FtsQuery, HybridQuery, RetrieveStore, SearchResult, VecInfo, VectorQuery, build_embedder,
+    dedup_chunk_results, merge_rrf,
 };
 // RetrieveDb is kept for backwards compatibility; prefer RetrieveStore + factory functions.
 #[allow(deprecated)]

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -6,7 +5,10 @@ use std::sync::{Arc, Mutex};
 use sapphire_retrieve::db::SCHEMA_VERSION;
 #[cfg(feature = "lancedb-store")]
 use sapphire_retrieve::open_lancedb;
-use sapphire_retrieve::{Document, Embedder, RetrieveStore, SearchResult, dedup_chunk_results};
+use sapphire_retrieve::{
+    Document, Embedder, FtsQuery, HybridQuery, RetrieveStore, SearchResult, VectorQuery,
+    dedup_chunk_results,
+};
 #[cfg(feature = "sqlite-store")]
 use sapphire_retrieve::{open_sqlite_fts, open_sqlite_vec};
 use tokio::sync::OnceCell;
@@ -520,13 +522,6 @@ impl WorkspaceState {
         params: &RetrieveParams<'_>,
         hybrid_config: &HybridConfig,
     ) -> Result<Vec<SearchResult>> {
-        // Over-fetch to compensate for post-filter losses.
-        let fetch_limit = if params.folder.is_some() {
-            params.limit * 3
-        } else {
-            params.limit
-        };
-
         // Fall back to FTS when the embedder is not available.
         let effective_mode = match params.mode {
             SearchMode::Semantic | SearchMode::Hybrid if self.embedder().is_none() => {
@@ -536,96 +531,64 @@ impl WorkspaceState {
         };
 
         let results = match effective_mode {
-            SearchMode::Fts => self.search_fts_internal(params.query, fetch_limit)?,
-            SearchMode::Semantic => self.search_semantic_internal(params.query, fetch_limit)?,
+            SearchMode::Fts => {
+                let q = FtsQuery::new(params.query).limit(params.limit);
+                let q = if let Some(f) = params.folder {
+                    q.path_prefix(f)
+                } else {
+                    q
+                };
+                self.retrieve_db().search_fts(&q)?
+            }
+            SearchMode::Semantic => {
+                self.search_semantic_internal(params.query, params.limit, params.folder)?
+            }
             SearchMode::Hybrid => {
-                self.search_hybrid_internal(params.query, fetch_limit, hybrid_config)?
+                self.search_hybrid_internal(params, hybrid_config)?
             }
         };
 
-        let results = Self::filter_by_folder(results, params.folder);
-        Ok(results.into_iter().take(params.limit).collect())
+        Ok(results)
     }
 
-    fn search_fts_internal(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
-        Ok(self.retrieve_db().search_fts(query, limit)?)
-    }
-
-    fn search_semantic_internal(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
+    fn search_semantic_internal(
+        &self,
+        query: &str,
+        limit: usize,
+        folder: Option<&Path>,
+    ) -> Result<Vec<SearchResult>> {
         let embedder = self.embedder().expect("caller verified embedder exists");
         let query_vecs = embedder.embed_texts(&[query])?;
         let query_vec = query_vecs.into_iter().next().ok_or_else(|| {
             sapphire_retrieve::Error::Embed("embedder returned empty result".into())
         })?;
-        let raw = self.retrieve_db().search_similar(&query_vec, limit * 3)?;
+        let mut vq = VectorQuery::new(&query_vec).limit(limit * 3);
+        if let Some(f) = folder {
+            vq = vq.path_prefix(f);
+        }
+        let raw = self.retrieve_db().search_similar(&vq)?;
         Ok(dedup_chunk_results(raw, limit))
     }
 
     fn search_hybrid_internal(
         &self,
-        query: &str,
-        limit: usize,
+        params: &RetrieveParams<'_>,
         config: &HybridConfig,
     ) -> Result<Vec<SearchResult>> {
-        let fts_results = self.search_fts_internal(query, limit)?;
-        let sem_results = self.search_semantic_internal(query, limit)?;
-        Ok(Self::merge_rrf(fts_results, sem_results, limit, config))
-    }
-
-    /// Merge two ranked result lists via Reciprocal Rank Fusion.
-    ///
-    /// `score(d) = w_fts / (k + rank_fts) + w_sem / (k + rank_sem)`
-    ///
-    /// Documents appearing in only one list receive a contribution from that
-    /// list alone.  The returned list is sorted by descending RRF score.
-    fn merge_rrf(
-        fts: Vec<SearchResult>,
-        semantic: Vec<SearchResult>,
-        limit: usize,
-        config: &HybridConfig,
-    ) -> Vec<SearchResult> {
-        let k = config.rrf_k as f64;
-        let w_fts = config.fts_weight;
-        let w_sem = 1.0 - w_fts;
-
-        let mut scores: HashMap<String, (SearchResult, f64)> = HashMap::new();
-
-        for (rank, result) in fts.into_iter().enumerate() {
-            let rrf = w_fts / (k + (rank + 1) as f64);
-            scores
-                .entry(result.path.clone())
-                .and_modify(|(_, s)| *s += rrf)
-                .or_insert((result, rrf));
+        let embedder = self.embedder().expect("caller verified embedder exists");
+        let query_vecs = embedder.embed_texts(&[params.query])?;
+        let query_vec = query_vecs.into_iter().next().ok_or_else(|| {
+            sapphire_retrieve::Error::Embed("embedder returned empty result".into())
+        })?;
+        let mut hq = HybridQuery::new(params.query, &query_vec)
+            .limit(params.limit)
+            .rrf_k(config.rrf_k as f64)
+            .weight_fts(config.fts_weight)
+            .weight_sem(1.0 - config.fts_weight);
+        if let Some(f) = params.folder {
+            hq = hq.path_prefix(f);
         }
-
-        for (rank, result) in semantic.into_iter().enumerate() {
-            let rrf = w_sem / (k + (rank + 1) as f64);
-            scores
-                .entry(result.path.clone())
-                .and_modify(|(_, s)| *s += rrf)
-                .or_insert((result, rrf));
-        }
-
-        let mut merged: Vec<_> = scores.into_values().collect();
-        merged.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-        merged.truncate(limit);
-
-        merged
-            .into_iter()
-            .map(|(mut result, rrf_score)| {
-                result.score = rrf_score;
-                result
-            })
-            .collect()
-    }
-
-    fn filter_by_folder(results: Vec<SearchResult>, folder: Option<&Path>) -> Vec<SearchResult> {
-        let Some(prefix) = folder else { return results };
-        let prefix_str = prefix.to_string_lossy();
-        results
-            .into_iter()
-            .filter(|r| r.path.starts_with(prefix_str.as_ref()))
-            .collect()
+        Ok(self.retrieve_db().search_hybrid(&hq)?)
     }
 
     // ── private helpers ───────────────────────────────────────────────────────

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -6,8 +6,7 @@ use sapphire_retrieve::db::SCHEMA_VERSION;
 #[cfg(feature = "lancedb-store")]
 use sapphire_retrieve::open_lancedb;
 use sapphire_retrieve::{
-    Document, Embedder, FtsQuery, HybridQuery, RetrieveStore, SearchResult, VectorQuery,
-    dedup_chunk_results,
+    Document, Embedder, FileSearchResult, FtsQuery, HybridQuery, RetrieveStore, VectorQuery,
 };
 #[cfg(feature = "sqlite-store")]
 use sapphire_retrieve::{open_sqlite_fts, open_sqlite_vec};
@@ -521,74 +520,46 @@ impl WorkspaceState {
         &self,
         params: &RetrieveParams<'_>,
         hybrid_config: &HybridConfig,
-    ) -> Result<Vec<SearchResult>> {
+    ) -> Result<Vec<FileSearchResult>> {
         // Fall back to FTS when the embedder is not available.
         let effective_mode = match params.mode {
-            SearchMode::Semantic | SearchMode::Hybrid if self.embedder().is_none() => {
-                SearchMode::Fts
-            }
+            SearchMode::Semantic if self.embedder().is_none() => SearchMode::Fts,
             other => other,
         };
 
         let results = match effective_mode {
             SearchMode::Fts => {
-                let q = FtsQuery::new(params.query).limit(params.limit);
-                let q = if let Some(f) = params.folder {
-                    q.path_prefix(f)
-                } else {
-                    q
-                };
+                let mut q = FtsQuery::new(params.query).limit(params.limit);
+                if let Some(f) = params.folder {
+                    q = q.path_prefix(f);
+                }
                 self.retrieve_db().search_fts(&q)?
             }
             SearchMode::Semantic => {
-                self.search_semantic_internal(params.query, params.limit, params.folder)?
+                let embedder = self.embedder().expect("caller verified embedder exists");
+                let mut vq = VectorQuery::new(params.query, embedder).limit(params.limit);
+                if let Some(f) = params.folder {
+                    vq = vq.path_prefix(f);
+                }
+                self.retrieve_db().search_similar(&vq)?
             }
             SearchMode::Hybrid => {
-                self.search_hybrid_internal(params, hybrid_config)?
+                let mut hq = HybridQuery::new(params.query)
+                    .limit(params.limit)
+                    .rrf_k(hybrid_config.rrf_k as f64)
+                    .weight_fts(hybrid_config.fts_weight)
+                    .weight_sem(1.0 - hybrid_config.fts_weight);
+                if let Some(e) = self.embedder() {
+                    hq = hq.embedder(e);
+                }
+                if let Some(f) = params.folder {
+                    hq = hq.path_prefix(f);
+                }
+                self.retrieve_db().search_hybrid(&hq)?
             }
         };
 
         Ok(results)
-    }
-
-    fn search_semantic_internal(
-        &self,
-        query: &str,
-        limit: usize,
-        folder: Option<&Path>,
-    ) -> Result<Vec<SearchResult>> {
-        let embedder = self.embedder().expect("caller verified embedder exists");
-        let query_vecs = embedder.embed_texts(&[query])?;
-        let query_vec = query_vecs.into_iter().next().ok_or_else(|| {
-            sapphire_retrieve::Error::Embed("embedder returned empty result".into())
-        })?;
-        let mut vq = VectorQuery::new(&query_vec).limit(limit * 3);
-        if let Some(f) = folder {
-            vq = vq.path_prefix(f);
-        }
-        let raw = self.retrieve_db().search_similar(&vq)?;
-        Ok(dedup_chunk_results(raw, limit))
-    }
-
-    fn search_hybrid_internal(
-        &self,
-        params: &RetrieveParams<'_>,
-        config: &HybridConfig,
-    ) -> Result<Vec<SearchResult>> {
-        let embedder = self.embedder().expect("caller verified embedder exists");
-        let query_vecs = embedder.embed_texts(&[params.query])?;
-        let query_vec = query_vecs.into_iter().next().ok_or_else(|| {
-            sapphire_retrieve::Error::Embed("embedder returned empty result".into())
-        })?;
-        let mut hq = HybridQuery::new(params.query, &query_vec)
-            .limit(params.limit)
-            .rrf_k(config.rrf_k as f64)
-            .weight_fts(config.fts_weight)
-            .weight_sem(1.0 - config.fts_weight);
-        if let Some(f) = params.folder {
-            hq = hq.path_prefix(f);
-        }
-        Ok(self.retrieve_db().search_hybrid(&hq)?)
     }
 
     // ── private helpers ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Rework the `sapphire-retrieve` search API so both full-text and semantic search operate on **chunks** and return file-level results (`Vec<FileSearchResult>`) with the matched chunks embedded. The motivation is MCP / AI consumption: when FTS matches, the client should know *where* inside a file the hit occurred, without re-reading the whole document. Also makes hybrid search the default path and pushes path-prefix filtering down into the backends.

Two commits, in order:

1. **Path-prefix filtering + hybrid on the trait** — `FtsQuery` / `VectorQuery` / `HybridQuery` builder structs with optional `path_prefix`; `RetrieveStore::search_hybrid` added with a default RRF implementation (SQLite `GLOB` / LanceDB `only_if` push-down).
2. **Chunk-level FTS + `FileSearchResult`** — the bigger refactor described below.

## Key changes

### New types and Query API

- `FileSearchResult { id, title, path, score, chunks: Vec<ChunkHit> }` replaces `SearchResult`.
- `ChunkHit { line_start, line_end, text, score }` replaces `ChunkSearchResult`.
- Query structs share `query: &str` as a common field:
  - `VectorQuery::new(query, embedder)` — embedder is mandatory; the backend embeds internally.
  - `HybridQuery::new(query)` + `.embedder(e)` — embedder is optional; `None` falls back to FTS-only.
- `RetrieveStore::search_hybrid` is exposed on the trait with a default implementation that calls `search_fts` + `search_similar` and merges via `merge_rrf_files`.
- `dedup_chunk_results` / doc-level `merge_rrf` removed.

### Chunk schema

- `(line, column)` → `(line_start, line_end)` (inclusive line range) on `TextChunk`, `Chunk`, and all storage schemas.
- `MarkdownChunker` records the range of each paragraph; `JsonChunker` tracks the opening/closing line of each array element (or JSONL line). Chunker tests cover single-line, multi-line, and nested-array cases.

### Storage

- **SQLite**: `documents_fts` removed; chunk-level `chunks_fts` (FTS5 trigram over `chunks.text`) added. `documents.body` column dropped. `idx_documents_path` added for efficient `GLOB` prefix filtering. `SCHEMA_VERSION` stays at 4 (bumped once in the first commit for `idx_documents_path`; schema redefined in the second). DBs with `user_version < 4` auto-wipe on first open — next sync re-indexes the workspace.
- **LanceDB**: FTS now indexes `chunks_meta.text`. `documents.body` field dropped. Schema version bumped 3 → 4 (`lancedb_v4/`); the old `lancedb_v3/` directory is no longer opened and can be removed manually.

### Callers

- `WorkspaceState::retrieve_files` simplified: builds the relevant Query struct and delegates. Over-fetch / post-filter removed (push-down handles both grouping and path prefix).
- MCP `search` tool now always uses `HybridQuery` (falls back automatically when no embedder is configured) and returns the richer chunk-annotated JSON.

## Migration impact

- **SQLite users**: any existing DB with `user_version < 4` is wiped on first open. The next `sync` / `watch` run re-indexes the workspace — the behavior is idempotent but the initial refresh will take as long as a fresh index build.
- **LanceDB users**: the old `lancedb_v3/` directory is left untouched (can be removed by hand); a new `lancedb_v4/` is created and populated by the next sync.
- **API users**: `SearchResult`, `ChunkSearchResult`, `dedup_chunk_results`, and the old `merge_rrf` are gone. Switch to `FileSearchResult` / `ChunkHit` / `merge_rrf_files`. Callers that pre-embedded query vectors before calling `search_similar` / `search_hybrid` should remove that step and pass an `&dyn Embedder` via the Query struct.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo check --all-features`
- [x] `cargo check -p sapphire-retrieve --no-default-features` (InMemory fallback)
- [x] `cargo test -p sapphire-retrieve --lib` — 14 chunker tests, including new multi-line paragraph and JSON array range coverage
- [ ] Manual: run MCP `search` against a mixed workspace (Markdown + JSONL) with and without an embedder configured; verify responses include the `chunks` array with sensible line ranges
- [ ] Manual: verify a pre-existing SQLite `.sapphire/retrieve.db` with schema version 3 is auto-wiped and re-indexed on first startup
- [ ] Manual: verify `path_prefix` (the CLI `--folder` / MCP `folder` option, if any) restricts results to the subtree in all three modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)