### PR TITLE
refactor(retrieve): drop title field from schema and domain types

### DIFF
--- a/crates/sapphire-retrieve/src/chunker.rs
+++ b/crates/sapphire-retrieve/src/chunker.rs
@@ -463,7 +463,7 @@ fn extract_message_text(value: &serde_json::Value) -> String {
 /// This function is used internally by the SQLite and LanceDB storage backends
 /// as the default chunking strategy when no pre-computed chunks are provided.
 /// New code should prefer the [`Chunker`] trait.
-pub fn chunk_document(title: &str, body: &str) -> Vec<String> {
+pub fn chunk_document(body: &str) -> Vec<String> {
     let paragraphs: Vec<&str> = body
         .split("\n\n")
         .map(str::trim)
@@ -471,19 +471,10 @@ pub fn chunk_document(title: &str, body: &str) -> Vec<String> {
         .collect();
 
     if paragraphs.is_empty() {
-        return vec![title.to_owned()];
+        return Vec::new();
     }
 
-    paragraphs
-        .iter()
-        .map(|p| {
-            if title.is_empty() {
-                p.to_string()
-            } else {
-                format!("{title}\n\n{p}")
-            }
-        })
-        .collect()
+    paragraphs.iter().map(|p| p.to_string()).collect()
 }
 
 #[cfg(test)]
@@ -492,27 +483,27 @@ mod tests {
 
     #[test]
     fn two_paragraphs() {
-        let chunks = chunk_document("Title", "First.\n\nSecond.");
+        let chunks = chunk_document("First.\n\nSecond.");
         assert_eq!(chunks.len(), 2);
-        assert_eq!(chunks[0], "Title\n\nFirst.");
-        assert_eq!(chunks[1], "Title\n\nSecond.");
+        assert_eq!(chunks[0], "First.");
+        assert_eq!(chunks[1], "Second.");
     }
 
     #[test]
-    fn empty_body_returns_title() {
-        let chunks = chunk_document("Title", "");
-        assert_eq!(chunks, vec!["Title"]);
+    fn empty_body_returns_empty() {
+        let chunks = chunk_document("");
+        assert!(chunks.is_empty());
     }
 
     #[test]
-    fn blank_only_body_returns_title() {
-        let chunks = chunk_document("Title", "   \n\n   ");
-        assert_eq!(chunks, vec!["Title"]);
+    fn blank_only_body_returns_empty() {
+        let chunks = chunk_document("   \n\n   ");
+        assert!(chunks.is_empty());
     }
 
     #[test]
-    fn empty_title() {
-        let chunks = chunk_document("", "Only body.");
+    fn single_paragraph() {
+        let chunks = chunk_document("Only body.");
         assert_eq!(chunks, vec!["Only body."]);
     }
 

--- a/crates/sapphire-retrieve/src/db.rs
+++ b/crates/sapphire-retrieve/src/db.rs
@@ -105,24 +105,22 @@ impl RetrieveStore for InMemoryStore {
                         return false;
                     }
                 }
-                doc.title.to_lowercase().contains(&needle)
-                    || doc.body.to_lowercase().contains(&needle)
+                doc.body.to_lowercase().contains(&needle)
             })
             .take(q.limit)
             .map(|doc| FileSearchResult {
                 id: doc.id,
-                title: doc.title.clone(),
                 path: doc.path.clone(),
                 score: 0.0,
                 chunks: vec![ChunkHit {
                     line_start: 0,
                     line_end: 0,
-                    text: doc.title.clone(),
+                    text: String::new(),
                     score: 0.0,
                 }],
             })
             .collect();
-        results.sort_by(|a, b| a.title.cmp(&b.title));
+        results.sort_by(|a, b| a.path.cmp(&b.path));
         Ok(results)
     }
 

--- a/crates/sapphire-retrieve/src/lancedb_store.rs
+++ b/crates/sapphire-retrieve/src/lancedb_store.rs
@@ -9,9 +9,9 @@
 //! | table           | columns                                                                                          |
 //! |-----------------|--------------------------------------------------------------------------------------------------|
 //! | `files`         | `path Utf8, mtime Int64`                                                                         |
-//! | `documents`     | `id Int64, title Utf8, path Utf8`                                                                |
-//! | `chunks_meta`   | `doc_id Int64, line_start Int32, line_end Int32, text Utf8, doc_title Utf8, doc_path Utf8`       |
-//! | `chunk_vectors` | `doc_id Int64, line_start Int32, line_end Int32, doc_title Utf8, doc_path Utf8, text Utf8, embedding FixedSizeList<Float32>` |
+//! | `documents`     | `id Int64, path Utf8`                                                                            |
+//! | `chunks_meta`   | `doc_id Int64, line_start Int32, line_end Int32, text Utf8, doc_path Utf8`                       |
+//! | `chunk_vectors` | `doc_id Int64, line_start Int32, line_end Int32, doc_path Utf8, text Utf8, embedding FixedSizeList<Float32>` |
 //!
 //! FTS is built on `chunks_meta.text` (chunk-level).
 
@@ -80,7 +80,6 @@ fn files_schema() -> Arc<Schema> {
 fn documents_schema() -> Arc<Schema> {
     Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int64, false),
-        Field::new("title", DataType::Utf8, false),
         Field::new("path", DataType::Utf8, false),
     ]))
 }
@@ -91,7 +90,6 @@ fn chunks_meta_schema() -> Arc<Schema> {
         Field::new("line_start", DataType::Int32, false),
         Field::new("line_end", DataType::Int32, false),
         Field::new("text", DataType::Utf8, false),
-        Field::new("doc_title", DataType::Utf8, false),
         Field::new("doc_path", DataType::Utf8, false),
     ]))
 }
@@ -101,7 +99,6 @@ fn chunk_vectors_schema(dim: i32) -> Arc<Schema> {
         Field::new("doc_id", DataType::Int64, false),
         Field::new("line_start", DataType::Int32, false),
         Field::new("line_end", DataType::Int32, false),
-        Field::new("doc_title", DataType::Utf8, false),
         Field::new("doc_path", DataType::Utf8, false),
         Field::new("text", DataType::Utf8, false),
         Field::new(
@@ -238,7 +235,6 @@ impl LanceFullStore {
             schema.clone(),
             vec![
                 Arc::new(Int64Array::from(vec![doc.id])),
-                Arc::new(StringArray::from(vec![doc.title.as_str()])),
                 Arc::new(StringArray::from(vec![doc.path.as_str()])),
             ],
         )
@@ -265,7 +261,7 @@ impl LanceFullStore {
         let chunks: &[(usize, usize, String)] = if let Some(ref c) = doc.chunks {
             c.as_slice()
         } else {
-            computed = chunk_document(&doc.title, &doc.body)
+            computed = chunk_document(&doc.body)
                 .into_iter()
                 .enumerate()
                 .map(|(i, t)| (i, i, t))
@@ -282,7 +278,6 @@ impl LanceFullStore {
         let doc_ids = vec![doc.id; n];
         let line_starts: Vec<i32> = chunks.iter().map(|(s, _, _)| *s as i32).collect();
         let line_ends: Vec<i32> = chunks.iter().map(|(_, e, _)| *e as i32).collect();
-        let titles = vec![doc.title.as_str(); n];
         let paths = vec![doc.path.as_str(); n];
         let texts: Vec<&str> = chunks.iter().map(|(_, _, t)| t.as_str()).collect();
 
@@ -293,7 +288,6 @@ impl LanceFullStore {
                 Arc::new(Int32Array::from(line_starts)),
                 Arc::new(Int32Array::from(line_ends)),
                 Arc::new(StringArray::from(texts)),
-                Arc::new(StringArray::from(titles)),
                 Arc::new(StringArray::from(paths)),
             ],
         )
@@ -338,7 +332,6 @@ impl LanceFullStore {
             .full_text_search(FullTextSearchQuery::new(query.to_owned()))
             .select(Select::Columns(vec![
                 "doc_id".to_string(),
-                "doc_title".to_string(),
                 "doc_path".to_string(),
                 "line_start".to_string(),
                 "line_end".to_string(),
@@ -355,9 +348,6 @@ impl LanceFullStore {
             let doc_ids = batch
                 .column_by_name("doc_id")
                 .and_then(|c| c.as_any().downcast_ref::<Int64Array>());
-            let titles = batch
-                .column_by_name("doc_title")
-                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
             let paths = batch
                 .column_by_name("doc_path")
                 .and_then(|c| c.as_any().downcast_ref::<StringArray>());
@@ -374,13 +364,12 @@ impl LanceFullStore {
                 .column_by_name("_score")
                 .and_then(|c| c.as_any().downcast_ref::<Float32Array>());
 
-            if let (Some(dids), Some(ttls), Some(pths), Some(ls), Some(le), Some(txts)) =
-                (doc_ids, titles, paths, line_starts, line_ends, texts)
+            if let (Some(dids), Some(pths), Some(ls), Some(le), Some(txts)) =
+                (doc_ids, paths, line_starts, line_ends, texts)
             {
                 for i in 0..batch.num_rows() {
                     rows.push(RawHit {
                         doc_id: dids.value(i),
-                        title: ttls.value(i).to_owned(),
                         path: pths.value(i).to_owned(),
                         line_start: ls.value(i) as usize,
                         line_end: le.value(i) as usize,
@@ -426,10 +415,6 @@ impl LanceFullStore {
                 .column_by_name("line_end")
                 .and_then(|c| c.as_any().downcast_ref::<Int32Array>())
                 .ok_or_else(|| Error::Embed("missing `line_end` in search result".into()))?;
-            let titles = batch
-                .column_by_name("doc_title")
-                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
-                .ok_or_else(|| Error::Embed("missing `doc_title` in search result".into()))?;
             let paths = batch
                 .column_by_name("doc_path")
                 .and_then(|c| c.as_any().downcast_ref::<StringArray>())
@@ -446,7 +431,6 @@ impl LanceFullStore {
             for i in 0..batch.num_rows() {
                 rows.push(RawHit {
                     doc_id: doc_ids.value(i),
-                    title: titles.value(i).to_owned(),
                     path: paths.value(i).to_owned(),
                     line_start: line_starts.value(i) as usize,
                     line_end: line_ends.value(i) as usize,
@@ -514,15 +498,12 @@ impl LanceFullStore {
             let texts = batch
                 .column_by_name("text")
                 .and_then(|c| c.as_any().downcast_ref::<StringArray>());
-            let titles = batch
-                .column_by_name("doc_title")
-                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
             let paths = batch
                 .column_by_name("doc_path")
                 .and_then(|c| c.as_any().downcast_ref::<StringArray>());
 
-            if let (Some(dids), Some(ls), Some(le), Some(txts), Some(ttls), Some(pths)) =
-                (doc_ids, line_starts, line_ends, texts, titles, paths)
+            if let (Some(dids), Some(ls), Some(le), Some(txts), Some(pths)) =
+                (doc_ids, line_starts, line_ends, texts, paths)
             {
                 for i in 0..batch.num_rows() {
                     let key = (dids.value(i), ls.value(i) as usize);
@@ -532,7 +513,6 @@ impl LanceFullStore {
                             line_start: key.1,
                             line_end: le.value(i) as usize,
                             text: txts.value(i).to_owned(),
-                            doc_title: ttls.value(i).to_owned(),
                             doc_path: pths.value(i).to_owned(),
                         });
                     }
@@ -550,7 +530,6 @@ impl LanceFullStore {
         let doc_ids: Vec<i64> = chunks.iter().map(|c| c.doc_id).collect();
         let line_starts: Vec<i32> = chunks.iter().map(|c| c.line_start as i32).collect();
         let line_ends: Vec<i32> = chunks.iter().map(|c| c.line_end as i32).collect();
-        let titles: Vec<&str> = chunks.iter().map(|c| c.doc_title.as_str()).collect();
         let paths: Vec<&str> = chunks.iter().map(|c| c.doc_path.as_str()).collect();
         let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
 
@@ -560,7 +539,6 @@ impl LanceFullStore {
                 Arc::new(Int64Array::from(doc_ids)),
                 Arc::new(Int32Array::from(line_starts)),
                 Arc::new(Int32Array::from(line_ends)),
-                Arc::new(StringArray::from(titles)),
                 Arc::new(StringArray::from(paths)),
                 Arc::new(StringArray::from(texts)),
                 Arc::new(make_embedding_array(embeddings, self.dim)?),
@@ -617,7 +595,6 @@ impl LanceFullStore {
 
 struct RawHit {
     doc_id: i64,
-    title: String,
     path: String,
     line_start: usize,
     line_end: usize,
@@ -634,7 +611,6 @@ where
     for r in rows {
         let entry = by_doc.entry(r.doc_id).or_insert_with(|| FileSearchResult {
             id: r.doc_id,
-            title: r.title.clone(),
             path: r.path.clone(),
             score: r.score,
             chunks: Vec::new(),

--- a/crates/sapphire-retrieve/src/retrieve_store.rs
+++ b/crates/sapphire-retrieve/src/retrieve_store.rs
@@ -169,8 +169,6 @@ impl std::fmt::Debug for HybridQuery<'_> {
 pub struct Document {
     /// Stable identifier assigned by the caller.
     pub id: i64,
-    /// Human-readable title (shown in search results).
-    pub title: String,
     /// Full body text; used only as input to the chunker when `chunks` is `None`.
     /// Not persisted to the database.
     pub body: String,
@@ -204,7 +202,6 @@ pub struct ChunkHit {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FileSearchResult {
     pub id: i64,
-    pub title: String,
     pub path: String,
     /// Representative score for the file (best chunk for FTS/vector,
     /// aggregated RRF score for hybrid).

--- a/crates/sapphire-retrieve/src/sqlite_store.rs
+++ b/crates/sapphire-retrieve/src/sqlite_store.rs
@@ -10,7 +10,7 @@
 //! | table | purpose |
 //! |-------|---------|
 //! | `files` | path + mtime tracking |
-//! | `documents` | id / title / path |
+//! | `documents` | id / path |
 //! | `chunks` | per-chunk text + source line range |
 //! | `chunks_fts` | FTS5 trigram index over `chunks.text` |
 //! | `chunk_vectors` | sqlite-vec virtual table (optional) |
@@ -55,10 +55,8 @@ CREATE TABLE IF NOT EXISTS files (
 
 CREATE TABLE IF NOT EXISTS documents (
     id    INTEGER PRIMARY KEY,
-    title TEXT    NOT NULL DEFAULT '',
     path  TEXT    NOT NULL DEFAULT ''
 );
-CREATE INDEX IF NOT EXISTS idx_documents_title ON documents(title);
 CREATE INDEX IF NOT EXISTS idx_documents_path  ON documents(path);
 
 CREATE TABLE IF NOT EXISTS chunks (
@@ -167,8 +165,8 @@ impl RetrieveStore for SqliteStore {
     fn upsert_document(&self, doc: &Document) -> Result<()> {
         let conn = self.open_conn()?;
         conn.execute(
-            "INSERT OR REPLACE INTO documents (id, title, path) VALUES (?1, ?2, ?3)",
-            params![doc.id, doc.title, doc.path],
+            "INSERT OR REPLACE INTO documents (id, path) VALUES (?1, ?2)",
+            params![doc.id, doc.path],
         )?;
         upsert_chunks(&conn, doc, self.dim.is_some())?;
         Ok(())
@@ -217,7 +215,7 @@ impl RetrieveStore for SqliteStore {
         let over_fetch = (q.limit * 5) as i64;
         let prefix_glob = q.path_prefix.map(|p| format!("{}*", p.to_string_lossy()));
         let sql = if prefix_glob.is_some() {
-            "SELECT c.doc_id, d.title, d.path, c.line_start, c.line_end, c.text, fts.rank
+            "SELECT c.doc_id, d.path, c.line_start, c.line_end, c.text, fts.rank
              FROM chunks_fts fts
              JOIN chunks c    ON c.id = fts.rowid
              JOIN documents d ON d.id = c.doc_id
@@ -225,7 +223,7 @@ impl RetrieveStore for SqliteStore {
              ORDER BY fts.rank
              LIMIT ?2"
         } else {
-            "SELECT c.doc_id, d.title, d.path, c.line_start, c.line_end, c.text, fts.rank
+            "SELECT c.doc_id, d.path, c.line_start, c.line_end, c.text, fts.rank
              FROM chunks_fts fts
              JOIN chunks c    ON c.id = fts.rowid
              JOIN documents d ON d.id = c.doc_id
@@ -333,7 +331,7 @@ impl RetrieveStore for SqliteStore {
         let over_fetch = (q.limit * 5) as i64;
 
         let mut stmt = conn.prepare(
-            "SELECT d.id, d.title, d.path, c.line_start, c.line_end, c.text, cv.distance
+            "SELECT d.id, d.path, c.line_start, c.line_end, c.text, cv.distance
              FROM chunk_vectors cv
              JOIN chunks c    ON c.id = cv.chunk_id
              JOIN documents d ON d.id = c.doc_id
@@ -461,7 +459,6 @@ fn ensure_vec_tables(conn: &Connection, dim: u32) -> Result<()> {
 
 struct ChunkRow {
     doc_id: i64,
-    title: String,
     path: String,
     line_start: usize,
     line_end: usize,
@@ -472,12 +469,11 @@ struct ChunkRow {
 fn map_chunk_row(row: &rusqlite::Row) -> rusqlite::Result<ChunkRow> {
     Ok(ChunkRow {
         doc_id: row.get::<_, i64>(0)?,
-        title: row.get::<_, String>(1)?,
-        path: row.get::<_, String>(2)?,
-        line_start: row.get::<_, i64>(3)? as usize,
-        line_end: row.get::<_, i64>(4)? as usize,
-        text: row.get::<_, String>(5)?,
-        score: row.get::<_, f64>(6).unwrap_or(0.0),
+        path: row.get::<_, String>(1)?,
+        line_start: row.get::<_, i64>(2)? as usize,
+        line_end: row.get::<_, i64>(3)? as usize,
+        text: row.get::<_, String>(4)?,
+        score: row.get::<_, f64>(5).unwrap_or(0.0),
     })
 }
 
@@ -495,7 +491,6 @@ where
     for r in rows {
         let entry = by_doc.entry(r.doc_id).or_insert_with(|| FileSearchResult {
             id: r.doc_id,
-            title: r.title.clone(),
             path: r.path.clone(),
             score: r.score,
             chunks: Vec::new(),
@@ -544,7 +539,7 @@ fn upsert_chunks(conn: &Connection, doc: &Document, has_vec: bool) -> Result<()>
     let chunks: &[(usize, usize, String)] = if let Some(ref c) = doc.chunks {
         c.as_slice()
     } else {
-        computed = chunk_document(&doc.title, &doc.body)
+        computed = chunk_document(&doc.body)
             .into_iter()
             .enumerate()
             .map(|(i, t)| (i, i, t))
@@ -668,7 +663,7 @@ fn collect_pending_chunks(
     embedded_keys: &HashSet<(i64, usize)>,
 ) -> Result<Vec<Chunk>> {
     let mut stmt = conn.prepare(
-        "SELECT c.doc_id, c.line_start, c.line_end, c.text, d.title, d.path
+        "SELECT c.doc_id, c.line_start, c.line_end, c.text, d.path
          FROM chunks c
          JOIN documents d ON d.id = c.doc_id",
     )?;
@@ -679,8 +674,7 @@ fn collect_pending_chunks(
                 line_start: row.get::<_, i64>(1)? as usize,
                 line_end: row.get::<_, i64>(2)? as usize,
                 text: row.get::<_, String>(3)?,
-                doc_title: row.get::<_, String>(4)?,
-                doc_path: row.get::<_, String>(5)?,
+                doc_path: row.get::<_, String>(4)?,
             })
         })?
         .filter_map(|r| r.ok())

--- a/crates/sapphire-retrieve/src/vector_store.rs
+++ b/crates/sapphire-retrieve/src/vector_store.rs
@@ -11,10 +11,8 @@ pub struct Chunk {
     pub line_start: usize,
     /// Last source line of this chunk (inclusive, 0-based).
     pub line_end: usize,
-    /// Embeddable text: title prepended to the extracted chunk body.
+    /// Embeddable text content of the chunk.
     pub text: String,
-    /// Denormalised document title (for display in search results).
-    pub doc_title: String,
     /// Denormalised absolute file path (for display in search results).
     pub doc_path: String,
 }

--- a/crates/sapphire-workspace-cli/src/mcp.rs
+++ b/crates/sapphire-workspace-cli/src/mcp.rs
@@ -141,7 +141,7 @@ impl RecallServer {
         When an embedder is configured, merges full-text and semantic search via \
         Reciprocal Rank Fusion; otherwise falls back to FTS-only. \
         Returns a JSON array of files ordered by relevance, each with \
-        `id`, `title`, `path`, `score`, and a `chunks` array giving the matched \
+        `id`, `path`, `score`, and a `chunks` array giving the matched \
         line ranges (`line_start`, `line_end`) and text within each file.")]
     fn search(&self, Parameters(p): Parameters<SearchParams>) -> Result<String, String> {
         (|| -> anyhow::Result<String> {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -90,46 +90,32 @@ pub fn sync_workspace(
             Err(_) => continue,
         };
 
-        let title = path
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_default();
         let doc_id = path_to_doc_id(path);
 
         let doc = if is_json {
-            // For JSON/JSONL: extract message chunks with source positions.
-            // The body is the extracted text (no JSON syntax), and each chunk
-            // carries the source line of its origin in the file.
-            let text_chunks = JsonChunker.chunk(&title, &raw);
+            let file_name = path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            let text_chunks = JsonChunker.chunk(&file_name, &raw);
             let body = text_chunks
                 .iter()
                 .map(|c| c.text.as_str())
                 .collect::<Vec<_>>()
                 .join("\n\n");
-            // Build embed text: prepend title to each chunk (same as chunk_document).
             let chunks: Vec<(usize, usize, String)> = text_chunks
                 .into_iter()
-                .map(|c| {
-                    let embed = if title.is_empty() {
-                        c.text.clone()
-                    } else {
-                        format!("{title}\n\n{}", c.text)
-                    };
-                    (c.line_start, c.line_end, embed)
-                })
+                .map(|c| (c.line_start, c.line_end, c.text))
                 .collect();
             Document {
                 id: doc_id,
-                title,
                 body,
                 path: path.to_string_lossy().into_owned(),
                 chunks: Some(chunks),
             }
         } else {
-            // For Markdown/text: use raw content as body, let backends auto-chunk.
             Document {
                 id: doc_id,
-                title,
                 body: raw,
                 path: path.to_string_lossy().into_owned(),
                 chunks: None,
@@ -226,13 +212,12 @@ pub fn sync_workspace_incremental(
             Err(_) => continue,
         };
 
-        let title = path
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_default();
-
         let doc = if is_json {
-            let text_chunks = JsonChunker.chunk(&title, &raw);
+            let file_name = path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            let text_chunks = JsonChunker.chunk(&file_name, &raw);
             let body = text_chunks
                 .iter()
                 .map(|c| c.text.as_str())
@@ -240,18 +225,10 @@ pub fn sync_workspace_incremental(
                 .join("\n\n");
             let chunks: Vec<(usize, usize, String)> = text_chunks
                 .into_iter()
-                .map(|c| {
-                    let embed = if title.is_empty() {
-                        c.text.clone()
-                    } else {
-                        format!("{title}\n\n{}", c.text)
-                    };
-                    (c.line_start, c.line_end, embed)
-                })
+                .map(|c| (c.line_start, c.line_end, c.text))
                 .collect();
             Document {
                 id: doc_id,
-                title,
                 body,
                 path: path_str.into_owned(),
                 chunks: Some(chunks),
@@ -259,7 +236,6 @@ pub fn sync_workspace_incremental(
         } else {
             Document {
                 id: doc_id,
-                title,
                 body: raw,
                 path: path_str.into_owned(),
                 chunks: None,

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -258,17 +258,12 @@ impl WorkspaceState {
             .unwrap_or(0);
 
         let body = std::fs::read_to_string(abs)?;
-        let title = abs
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_default();
         let doc_id = path_to_doc_id(abs);
 
         let db = self.retrieve_db();
         db.upsert_file(&path_str, mtime)?;
         db.upsert_document(&Document {
             id: doc_id,
-            title,
             body,
             path: path_str,
             chunks: None,


### PR DESCRIPTION
## Summary

- Removes the `title` field from the retrieve library's domain types (`Document`, `FileSearchResult`) and storage schemas (`documents.title`, `chunks_meta.doc_title`, `chunk_vectors.doc_title`).
- Stops prepending the title to each chunk's embed text. Chunks now carry pure content, and `chunk_document(body)` takes a single argument.
- Display-name resolution (frontmatter, H1, etc.) is left to the application layer, which can map `path` to a title however it likes.

## Why

`title` was always derived from `path.file_name()`, so it added no information beyond `path` while duplicating a string into every chunk row — both in storage (denormalised `doc_title` on `chunks_meta` / `chunk_vectors`) and in the embedding input (every chunk's text was `"{title}\n\n{chunk}"`). The filename doesn't meaningfully help embedding quality, and for non-ASCII filenames the file-name-as-title convention is often wrong anyway.

Keeping title resolution in the application layer also means format-specific logic (Markdown H1, JSON metadata, etc.) doesn't leak into the retrieve library.

## Schema version

`SCHEMA_VERSION` stays at `4`. Version 4 is unreleased, so no bump is needed — this change is folded into the same schema break.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test -p sapphire-retrieve` — 14 unit tests + 1 doctest pass
- [ ] Verify a fresh index on a workspace produces expected FTS and vector search results
- [ ] Verify search results still return the correct `path` (no stale `title` references in clients)

🤖 Generated with [Claude Code](https://claude.com/claude-code)