### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `sapphire-workspace` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] - 2026-04-18
 
 ### Changed (breaking)
 
@@ -17,6 +17,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `sapphire-retrieve`: chunk schema changed from `(line, column)` to `(line_start, line_end)` — inclusive line range. `TextChunk`, `Chunk`, and all backend schemas updated.
 - `sapphire-retrieve`: `documents.body` column / field dropped from storage (still used as chunker input when `Document::chunks` is `None`). SQLite `documents_fts` virtual table removed; LanceDB FTS now indexes `chunks_meta.text`.
 - `sapphire-retrieve`: **schema migration required.** SQLite databases on version `<4` are automatically wiped and recreated on first open (next sync re-indexes the workspace). LanceDB is bumped to `lancedb_v4/`; the old `lancedb_v3/` directory is no longer used and can be removed manually.
+- `sapphire-retrieve`: `title` field removed from `Document` and `FileSearchResult`; `doc_title` dropped from `Chunk` and all backend schemas. Embedding text no longer prepends the title. Display names should be resolved by the application layer from `path`. (#43)
+
+### Added
+
+- `sapphire-workspace`: file operation methods (`read_file`, `read_file_range`, `write_file`, `append_file`, `delete_file`) now validate that paths resolve within the workspace root, preventing path traversal attacks. A new `allow_external_paths` flag on `AppContext` lets applications opt in to external file access — external files use plain `std::fs` without index or sync updates. (#42)
 
 ## [0.8.1] - 2026-04-13
 
@@ -157,6 +162,7 @@ Internal repository restructure; no public API changes.
 - `fastembed-embed`, `lancedb-store`, `sqlite-store`, `git-sync` feature flags.
 - Re-exports of `sapphire-retrieve` and `sapphire-sync` public APIs.
 
+[0.9.0]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.8.1...workspace-v0.9.0
 [0.8.1]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.8.0...workspace-v0.8.1
 [0.8.0]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.7.1...workspace-v0.8.0
 [0.7.1]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.7.0...workspace-v0.7.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.8.1"
+version = "0.9.0"
 description = "Workspace management library for indexing, search, and sync of file-based documents"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-workspace"
@@ -52,8 +52,8 @@ fastembed-embed = ["sapphire-retrieve/fastembed-embed"]
 git-sync        = ["sapphire-sync/git"]
 
 [dependencies]
-sapphire-retrieve = { version = "0.8.1", path = "crates/sapphire-retrieve", default-features = false }
-sapphire-sync     = { version = "0.8.1", path = "crates/sapphire-sync", default-features = false }
+sapphire-retrieve = { version = "0.9.0", path = "crates/sapphire-retrieve", default-features = false }
+sapphire-sync     = { version = "0.9.0", path = "crates/sapphire-sync", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/sapphire-retrieve/src/lancedb_store.rs
+++ b/crates/sapphire-retrieve/src/lancedb_store.rs
@@ -39,9 +39,7 @@ use crate::{
     chunker::chunk_document,
     embed::Embedder,
     error::{Error, Result},
-    retrieve_store::{
-        ChunkHit, Document, FileSearchResult, FtsQuery, RetrieveStore, VectorQuery,
-    },
+    retrieve_store::{ChunkHit, Document, FileSearchResult, FtsQuery, RetrieveStore, VectorQuery},
     vector_store::{Chunk, VecInfo},
 };
 

--- a/crates/sapphire-retrieve/src/retrieve_store.rs
+++ b/crates/sapphire-retrieve/src/retrieve_store.rs
@@ -10,11 +10,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use crate::{
-    embed::Embedder,
-    error::Result,
-    vector_store::VecInfo,
-};
+use crate::{embed::Embedder, error::Result, vector_store::VecInfo};
 
 // ── query structs ────────────────────────────────────────────────────────────
 

--- a/crates/sapphire-retrieve/src/sqlite_store.rs
+++ b/crates/sapphire-retrieve/src/sqlite_store.rs
@@ -29,9 +29,7 @@ use crate::{
     chunker::chunk_document,
     embed::Embedder,
     error::{Error, Result},
-    retrieve_store::{
-        ChunkHit, Document, FileSearchResult, FtsQuery, RetrieveStore, VectorQuery,
-    },
+    retrieve_store::{ChunkHit, Document, FileSearchResult, FtsQuery, RetrieveStore, VectorQuery},
     vector_store::{Chunk, VecInfo, vec_serialize},
 };
 
@@ -547,17 +545,12 @@ fn upsert_chunks(conn: &Connection, doc: &Document, has_vec: bool) -> Result<()>
         &computed
     };
 
-    let live_starts: HashSet<i64> = chunks
-        .iter()
-        .map(|(start, _, _)| *start as i64)
-        .collect();
+    let live_starts: HashSet<i64> = chunks.iter().map(|(start, _, _)| *start as i64).collect();
 
     // Delete stale chunks (FTS5 external-content: need to insert 'delete' rows
     // before dropping the underlying row, or rebuild the index after).
     let old_rows: Vec<(i64, i64, String)> = {
-        let mut stmt = conn.prepare(
-            "SELECT id, line_start, text FROM chunks WHERE doc_id = ?1",
-        )?;
+        let mut stmt = conn.prepare("SELECT id, line_start, text FROM chunks WHERE doc_id = ?1")?;
         stmt.query_map([doc.id], |row| {
             Ok((
                 row.get::<_, i64>(0)?,

--- a/crates/sapphire-sync/src/git_sync.rs
+++ b/crates/sapphire-sync/src/git_sync.rs
@@ -171,7 +171,10 @@ impl GitSync {
     /// Conflict resolution: when two sides modify the same file, the version
     /// from the commit with the newer (higher) author timestamp is kept.
     fn sync_git(repo: &Repository, remote_name: &str) -> Result<()> {
-        info!(remote = remote_name, "sync_git: starting fetch → merge → push cycle");
+        info!(
+            remote = remote_name,
+            "sync_git: starting fetch → merge → push cycle"
+        );
 
         // ── 1. Fetch ──────────────────────────────────────────────────────────
         let mut remote = repo

--- a/crates/sapphire-workspace-cli/Cargo.toml
+++ b/crates/sapphire-workspace-cli/Cargo.toml
@@ -19,7 +19,7 @@ fastembed-embed = ["sapphire-workspace/fastembed-embed"]
 git-sync        = ["sapphire-workspace/git-sync"]
 
 [dependencies]
-sapphire-workspace = { version = "0.8.1", path = "../..", default-features = false }
+sapphire-workspace = { version = "0.9.0", path = "../..", default-features = false }
 clap.workspace = true
 anyhow.workspace = true
 serde.workspace = true

--- a/crates/sapphire-workspace-cli/src/mcp.rs
+++ b/crates/sapphire-workspace-cli/src/mcp.rs
@@ -137,12 +137,14 @@ impl RecallServer {
         .map_err(|e| e.to_string())
     }
 
-    #[tool(description = "Search indexed documents using hybrid (FTS + vector) search. \
+    #[tool(
+        description = "Search indexed documents using hybrid (FTS + vector) search. \
         When an embedder is configured, merges full-text and semantic search via \
         Reciprocal Rank Fusion; otherwise falls back to FTS-only. \
         Returns a JSON array of files ordered by relevance, each with \
         `id`, `path`, `score`, and a `chunks` array giving the matched \
-        line ranges (`line_start`, `line_end`) and text within each file.")]
+        line ranges (`line_start`, `line_end`) and text within each file."
+    )]
     fn search(&self, Parameters(p): Parameters<SearchParams>) -> Result<String, String> {
         (|| -> anyhow::Result<String> {
             self.with_state(|s| {

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -99,9 +99,7 @@ fn canonicalize_or_parent(path: &Path) -> std::io::Result<PathBuf> {
     let mut current = path;
     loop {
         if let Some(parent) = current.parent() {
-            let name = current
-                .file_name()
-                .unwrap_or(current.as_os_str());
+            let name = current.file_name().unwrap_or(current.as_os_str());
             suffix = Path::new(name).join(&suffix);
             match parent.canonicalize() {
                 Ok(canon) => return Ok(canon.join(suffix)),


### PR DESCRIPTION
## Summary

- Bump workspace version to 0.9.0
- Update CHANGELOG with changes from #41 / #42 / #43

### Changed (breaking)
- `sapphire-retrieve`: chunk-level FTS — `search_fts`/`search_similar`/`search_hybrid` now return `Vec<FileSearchResult>` with per-chunk line ranges (`line_start`, `line_end`) (#41)
- `sapphire-retrieve`: `SearchResult`/`ChunkSearchResult`/`dedup_chunk_results`/`merge_rrf` removed; replaced by `FileSearchResult`/`ChunkHit`/`merge_rrf_files` (#41)
- `sapphire-retrieve`: query structs `FtsQuery`/`VectorQuery`/`HybridQuery` introduced; callers no longer pre-compute embeddings (#41)
- `sapphire-retrieve`: `path_prefix` filtering pushed down to SQLite/LanceDB backends (#41)
- `sapphire-retrieve`: chunk schema changed from `(line, column)` to `(line_start, line_end)`; schema migration required (auto-wipe on version <4) (#41)
- `sapphire-retrieve`: `title` field removed from `Document`/`FileSearchResult`; `doc_title` dropped from `Chunk` and all backend schemas (#43)

### Added
- `sapphire-workspace`: path traversal validation on file operation methods; `AppContext::allow_external_paths` flag for opting in to external file access (#42)

## Test plan

- [x] `cargo check` passes
- [x] `cargo publish --dry-run` passes
- [ ] CI passes (fmt, clippy, test)
- [ ] Merge triggers release workflow (build, cargo publish, GitHub release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)