### PR TITLE
feat(sync): add device registry synced via devices.jsonl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,4 +62,5 @@ tracing.workspace = true
 indexmap.workspace = true
 walkdir = "2"
 uuid.workspace = true
+chrono = { workspace = true }
 md-5 = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ thiserror.workspace = true
 serde.workspace = true
 toml.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tracing.workspace = true
 indexmap.workspace = true
 walkdir = "2"
 uuid.workspace = true

--- a/crates/sapphire-sync/Cargo.toml
+++ b/crates/sapphire-sync/Cargo.toml
@@ -10,12 +10,14 @@ categories = ["filesystem"]
 
 [features]
 default = ["git"]
-git = ["dep:git2", "dep:dirs", "dep:uuid"]
+git = ["dep:git2", "dep:dirs"]
 
 [dependencies]
 tracing.workspace = true
 thiserror.workspace = true
 serde.workspace = true
-uuid = { workspace = true, optional = true }
+serde_json.workspace = true
+chrono = { workspace = true }
+uuid = { workspace = true }
 dirs = { workspace = true, optional = true }
 git2 = { version = "0.20", optional = true }

--- a/crates/sapphire-sync/src/devices.rs
+++ b/crates/sapphire-sync/src/devices.rs
@@ -1,0 +1,415 @@
+//! Device registry synchronised via the marker directory.
+//!
+//! The registry is persisted as a JSONL file (one JSON object per line)
+//! under the workspace marker directory (e.g.
+//! `.sapphire-workspace/devices.jsonl`).  Each record describes one
+//! device that has ever synced this workspace.  Records are sorted by
+//! their UUIDv7 id, which — because UUIDv7 encodes a millisecond
+//! timestamp in the high bits — means the file is effectively ordered by
+//! first-registration time and the 1-based index of a record is a
+//! stable "device number" across peers.
+//!
+//! Conflict resolution: when two devices append their initial entry at
+//! the same time without syncing, the existing git merge strategy
+//! (newest author timestamp wins) may drop one of the lines.  Because
+//! [`DeviceRegistry::ensure_registered`] is idempotent, the losing
+//! device will simply re-add its entry on the next workspace open —
+//! the registry self-heals without custom merge logic.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{Error, Result};
+
+/// One device's entry in the registry.
+///
+/// All fields except `name` are populated at initial registration time
+/// and (with the exception of `client` / `client_version` — see
+/// [`DeviceRegistry::ensure_registered`]) are never rewritten.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeviceRecord {
+    /// Stable per-device UUIDv7.  Primary key; never changes.
+    pub id: Uuid,
+    /// Human-readable name.  Initially seeded from the system hostname,
+    /// but the user can override via an explicit command.
+    pub name: String,
+    /// System hostname at the time of registration.  Kept verbatim so
+    /// renaming the machine later doesn't rewrite history.
+    pub hostname: String,
+    /// Cargo package name of the client that wrote this record.
+    pub client: String,
+    /// Cargo package version of the client that most recently touched
+    /// this record (auto-updated on workspace open when the binary
+    /// version changes — see [`DeviceRegistry::ensure_registered`]).
+    pub client_version: String,
+    /// `std::env::consts::OS` at registration time.
+    pub platform: String,
+    /// `std::env::consts::ARCH` at registration time.
+    pub arch: String,
+    /// When this device first registered against this workspace.
+    pub registered_at: DateTime<Utc>,
+    /// When any field was last updated.  Used to resolve cross-workspace
+    /// propagation of the editable fields (currently just `name`).
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Machine-detected values supplied by the caller when registering a
+/// device for the first time, or when reconciling `client` /
+/// `client_version` on a subsequent open.
+#[derive(Clone, Debug)]
+pub struct DeviceDefaults {
+    /// Seed value for [`DeviceRecord::name`].  Usually the hostname.
+    pub name: String,
+    pub hostname: String,
+    pub client: String,
+    pub client_version: String,
+    pub platform: String,
+    pub arch: String,
+}
+
+/// Registry of devices that have synced this workspace.
+#[derive(Debug)]
+pub struct DeviceRegistry {
+    path: PathBuf,
+    records: Vec<DeviceRecord>,
+}
+
+impl DeviceRegistry {
+    /// Load the registry from `path`.  Missing file ⇒ empty registry.
+    ///
+    /// Returns [`Error::DeviceRecordParse`] on the first unparseable
+    /// line.  Blank lines are skipped silently.
+    pub fn load(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        let records = match fs::read_to_string(&path) {
+            Ok(contents) => parse_jsonl(&path, &contents)?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+            Err(e) => {
+                return Err(Error::Io { path, source: e });
+            }
+        };
+        let mut this = Self { path, records };
+        this.sort();
+        Ok(this)
+    }
+
+    /// Write the registry back to disk (sorted by UUIDv7, LF-terminated).
+    pub fn save(&self) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).map_err(|e| Error::Io {
+                path: parent.to_owned(),
+                source: e,
+            })?;
+        }
+        let mut buf = String::new();
+        for record in &self.records {
+            let line = serde_json::to_string(record).expect("DeviceRecord serialisation");
+            buf.push_str(&line);
+            buf.push('\n');
+        }
+        fs::write(&self.path, buf).map_err(|e| Error::Io {
+            path: self.path.clone(),
+            source: e,
+        })
+    }
+
+    /// On-disk path of this registry file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Registered devices, UUIDv7 (== registration-time) order.
+    pub fn records(&self) -> &[DeviceRecord] {
+        &self.records
+    }
+
+    /// Idempotent self-registration + lightweight reconciliation.
+    ///
+    /// - No existing entry for `id`: append a fresh record populated
+    ///   from `defaults` with `registered_at == updated_at == now`.
+    ///   Returns `Ok(true)`.
+    /// - Existing entry whose `client` or `client_version` differs from
+    ///   `defaults`: overwrite just those two fields (and `updated_at`).
+    ///   This is the only "automatic" in-place update — every other
+    ///   field stays as originally registered.  Returns `Ok(true)`.
+    /// - Otherwise: leave the record alone, return `Ok(false)`.
+    ///
+    /// The caller is expected to [`save`](Self::save) and stage the
+    /// file only when this returns `Ok(true)`.
+    pub fn ensure_registered(&mut self, id: Uuid, defaults: DeviceDefaults) -> Result<bool> {
+        let now = Utc::now();
+        if let Some(existing) = self.records.iter_mut().find(|r| r.id == id) {
+            if existing.client == defaults.client
+                && existing.client_version == defaults.client_version
+            {
+                return Ok(false);
+            }
+            existing.client = defaults.client;
+            existing.client_version = defaults.client_version;
+            existing.updated_at = now;
+            return Ok(true);
+        }
+        self.records.push(DeviceRecord {
+            id,
+            name: defaults.name,
+            hostname: defaults.hostname,
+            client: defaults.client,
+            client_version: defaults.client_version,
+            platform: defaults.platform,
+            arch: defaults.arch,
+            registered_at: now,
+            updated_at: now,
+        });
+        self.sort();
+        Ok(true)
+    }
+
+    /// Update the human-readable name for `id` and bump `updated_at`.
+    ///
+    /// Fails with [`Error::DeviceNotFound`] if the id isn't in the
+    /// registry yet.  Never touches any other field.
+    pub fn set_name(&mut self, id: Uuid, name: &str) -> Result<()> {
+        let record = self
+            .records
+            .iter_mut()
+            .find(|r| r.id == id)
+            .ok_or(Error::DeviceNotFound { id })?;
+        record.name = name.to_owned();
+        record.updated_at = Utc::now();
+        Ok(())
+    }
+
+    /// Overwrite the matching record with `record` iff the incoming
+    /// `updated_at` is strictly newer.  If there is no matching record
+    /// yet, the incoming record is inserted.  Intended for a GUI that
+    /// holds multiple workspaces open and wants to propagate name
+    /// changes between them.
+    ///
+    /// Returns `Ok(true)` when the stored state changed.
+    pub fn update_if_newer(&mut self, record: DeviceRecord) -> Result<bool> {
+        if let Some(existing) = self.records.iter_mut().find(|r| r.id == record.id) {
+            if record.updated_at <= existing.updated_at {
+                return Ok(false);
+            }
+            *existing = record;
+            return Ok(true);
+        }
+        self.records.push(record);
+        self.sort();
+        Ok(true)
+    }
+
+    /// Find the record for `id`.
+    pub fn lookup(&self, id: Uuid) -> Option<&DeviceRecord> {
+        self.records.iter().find(|r| r.id == id)
+    }
+
+    /// 1-based index of `id` in UUIDv7 order, i.e. the "Device Number"
+    /// exposed to users.  `None` if `id` is not registered.
+    pub fn device_number(&self, id: Uuid) -> Option<usize> {
+        self.records.iter().position(|r| r.id == id).map(|i| i + 1)
+    }
+
+    fn sort(&mut self) {
+        self.records.sort_by_key(|r| r.id);
+    }
+}
+
+fn parse_jsonl(path: &Path, contents: &str) -> Result<Vec<DeviceRecord>> {
+    let mut out = Vec::new();
+    for (i, line) in contents.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record =
+            serde_json::from_str::<DeviceRecord>(line).map_err(|e| Error::DeviceRecordParse {
+                path: path.to_owned(),
+                line: i + 1,
+                source: e,
+            })?;
+        out.push(record);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn defaults(name: &str) -> DeviceDefaults {
+        DeviceDefaults {
+            name: name.to_owned(),
+            hostname: name.to_owned(),
+            client: "sapphire-workspace-cli".to_owned(),
+            client_version: "0.9.0".to_owned(),
+            platform: "linux".to_owned(),
+            arch: "x86_64".to_owned(),
+        }
+    }
+
+    fn tmp_path(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "sapphire-devices-test-{}-{}",
+            std::process::id(),
+            name
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir.join("devices.jsonl")
+    }
+
+    #[test]
+    fn load_missing_file_is_empty() {
+        let path = tmp_path("missing").with_file_name("does-not-exist.jsonl");
+        let registry = DeviceRegistry::load(path).unwrap();
+        assert!(registry.records().is_empty());
+    }
+
+    #[test]
+    fn ensure_registered_first_time_appends_with_matching_timestamps() {
+        let path = tmp_path("first");
+        let _ = fs::remove_file(&path);
+        let mut registry = DeviceRegistry::load(&path).unwrap();
+        let id = Uuid::now_v7();
+        let added = registry.ensure_registered(id, defaults("my-host")).unwrap();
+        assert!(added);
+        let r = registry.lookup(id).unwrap();
+        assert_eq!(r.name, "my-host");
+        assert_eq!(r.registered_at, r.updated_at);
+    }
+
+    #[test]
+    fn ensure_registered_is_idempotent() {
+        let path = tmp_path("idem");
+        let _ = fs::remove_file(&path);
+        let mut registry = DeviceRegistry::load(&path).unwrap();
+        let id = Uuid::now_v7();
+        assert!(registry.ensure_registered(id, defaults("a")).unwrap());
+        let first_updated = registry.lookup(id).unwrap().updated_at;
+        // Sleep briefly so that if a bug writes Utc::now, the timestamp would differ.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        assert!(!registry.ensure_registered(id, defaults("a")).unwrap());
+        assert_eq!(registry.lookup(id).unwrap().updated_at, first_updated);
+    }
+
+    #[test]
+    fn ensure_registered_syncs_client_version_only() {
+        let path = tmp_path("cv");
+        let _ = fs::remove_file(&path);
+        let mut registry = DeviceRegistry::load(&path).unwrap();
+        let id = Uuid::now_v7();
+        registry.ensure_registered(id, defaults("a")).unwrap();
+        let before = registry.lookup(id).unwrap().clone();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let mut new_defaults = defaults("ignored-name");
+        new_defaults.client_version = "1.0.0".to_owned();
+        new_defaults.hostname = "also-ignored".to_owned();
+        new_defaults.platform = "macos".to_owned();
+        new_defaults.arch = "aarch64".to_owned();
+        assert!(registry.ensure_registered(id, new_defaults).unwrap());
+        let after = registry.lookup(id).unwrap();
+        assert_eq!(after.client_version, "1.0.0");
+        // Unchanged fields:
+        assert_eq!(after.name, before.name);
+        assert_eq!(after.hostname, before.hostname);
+        assert_eq!(after.platform, before.platform);
+        assert_eq!(after.arch, before.arch);
+        assert_eq!(after.registered_at, before.registered_at);
+        assert!(after.updated_at > before.updated_at);
+    }
+
+    #[test]
+    fn ensure_registered_keeps_uuidv7_order() {
+        let path = tmp_path("order");
+        let _ = fs::remove_file(&path);
+        let mut registry = DeviceRegistry::load(&path).unwrap();
+        let a = Uuid::now_v7();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let b = Uuid::now_v7();
+        // Register in reversed order — storage should still be UUIDv7 ascending.
+        registry.ensure_registered(b, defaults("b")).unwrap();
+        registry.ensure_registered(a, defaults("a")).unwrap();
+        let ids: Vec<Uuid> = registry.records().iter().map(|r| r.id).collect();
+        assert_eq!(ids, vec![a, b]);
+        assert_eq!(registry.device_number(a), Some(1));
+        assert_eq!(registry.device_number(b), Some(2));
+    }
+
+    #[test]
+    fn save_load_roundtrip_preserves_all_fields() {
+        let path = tmp_path("rt");
+        let _ = fs::remove_file(&path);
+        let mut registry = DeviceRegistry::load(&path).unwrap();
+        let id = Uuid::now_v7();
+        registry.ensure_registered(id, defaults("round")).unwrap();
+        registry.save().unwrap();
+
+        let reloaded = DeviceRegistry::load(&path).unwrap();
+        assert_eq!(reloaded.records(), registry.records());
+    }
+
+    #[test]
+    fn set_name_bumps_updated_at_only() {
+        let path = tmp_path("setname");
+        let _ = fs::remove_file(&path);
+        let mut registry = DeviceRegistry::load(&path).unwrap();
+        let id = Uuid::now_v7();
+        registry.ensure_registered(id, defaults("seed")).unwrap();
+        let before = registry.lookup(id).unwrap().clone();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        registry.set_name(id, "alice-laptop").unwrap();
+        let after = registry.lookup(id).unwrap();
+        assert_eq!(after.name, "alice-laptop");
+        assert_eq!(after.id, before.id);
+        assert_eq!(after.registered_at, before.registered_at);
+        assert_eq!(after.hostname, before.hostname);
+        assert_eq!(after.client, before.client);
+        assert_eq!(after.client_version, before.client_version);
+        assert_eq!(after.platform, before.platform);
+        assert_eq!(after.arch, before.arch);
+        assert!(after.updated_at > before.updated_at);
+    }
+
+    #[test]
+    fn set_name_unknown_id_errors() {
+        let mut registry = DeviceRegistry::load(tmp_path("setname-missing")).unwrap();
+        let err = registry.set_name(Uuid::now_v7(), "nope").unwrap_err();
+        assert!(matches!(err, Error::DeviceNotFound { .. }));
+    }
+
+    #[test]
+    fn update_if_newer_respects_updated_at() {
+        let path = tmp_path("newer");
+        let _ = fs::remove_file(&path);
+        let mut registry = DeviceRegistry::load(&path).unwrap();
+        let id = Uuid::now_v7();
+        registry.ensure_registered(id, defaults("old")).unwrap();
+
+        let mut incoming = registry.lookup(id).unwrap().clone();
+        incoming.name = "old-but-older".to_owned();
+        incoming.updated_at =
+            registry.lookup(id).unwrap().updated_at - chrono::Duration::seconds(10);
+        assert!(!registry.update_if_newer(incoming).unwrap());
+        assert_ne!(registry.lookup(id).unwrap().name, "old-but-older");
+
+        let mut fresh = registry.lookup(id).unwrap().clone();
+        fresh.name = "winner".to_owned();
+        fresh.updated_at = Utc::now() + chrono::Duration::seconds(1);
+        assert!(registry.update_if_newer(fresh).unwrap());
+        assert_eq!(registry.lookup(id).unwrap().name, "winner");
+    }
+
+    #[test]
+    fn malformed_line_reports_error_with_line_number() {
+        let path = tmp_path("malformed");
+        fs::write(&path, "not-json\n").unwrap();
+        let err = DeviceRegistry::load(&path).unwrap_err();
+        match err {
+            Error::DeviceRecordParse { line, .. } => assert_eq!(line, 1),
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+}

--- a/crates/sapphire-sync/src/devices.rs
+++ b/crates/sapphire-sync/src/devices.rs
@@ -12,9 +12,9 @@
 //! Conflict resolution: when two devices append their initial entry at
 //! the same time without syncing, the existing git merge strategy
 //! (newest author timestamp wins) may drop one of the lines.  Because
-//! [`DeviceRegistry::ensure_registered`] is idempotent, the losing
-//! device will simply re-add its entry on the next workspace open —
-//! the registry self-heals without custom merge logic.
+//! [`DeviceRegistry::merge_device_context`] is idempotent, the losing
+//! device will re-add its entry on the next workspace open — the
+//! registry self-heals without custom merge logic.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -26,49 +26,111 @@ use uuid::Uuid;
 use crate::{Error, Result};
 
 /// One device's entry in the registry.
-///
-/// All fields except `name` are populated at initial registration time
-/// and (with the exception of `client` / `client_version` — see
-/// [`DeviceRegistry::ensure_registered`]) are never rewritten.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeviceRecord {
     /// Stable per-device UUIDv7.  Primary key; never changes.
     pub id: Uuid,
-    /// Human-readable name.  Initially seeded from the system hostname,
-    /// but the user can override via an explicit command.
+    /// Human-readable name.  Seeded from the hostname at first
+    /// registration; the user can rename it via
+    /// [`DeviceRegistry::set_name`] or the equivalent CLI command.
     pub name: String,
-    /// System hostname at the time of registration.  Kept verbatim so
-    /// renaming the machine later doesn't rewrite history.
+    /// System hostname at the time the record was last written.  The
+    /// app-level context always wins when this field differs from the
+    /// app's current value, so peers see the latest hostname after any
+    /// merge.
     pub hostname: String,
-    /// Cargo package name of the client that wrote this record.
-    pub client: String,
-    /// Cargo package version of the client that most recently touched
-    /// this record (auto-updated on workspace open when the binary
-    /// version changes — see [`DeviceRegistry::ensure_registered`]).
-    pub client_version: String,
-    /// `std::env::consts::OS` at registration time.
+    /// Cargo package name of the binary that wrote this record
+    /// (e.g. `"sapphire-workspace-cli"`, `"sapphire-workspace-gui"`).
+    /// Distinct from [`AppContext::app_name`](crate::Error) which names
+    /// the workspace format shared across all binaries.
+    pub app_id: String,
+    /// Cargo package version of the binary that wrote this record.
+    pub app_version: String,
+    /// `std::env::consts::OS` at the time the record was last written.
     pub platform: String,
-    /// `std::env::consts::ARCH` at registration time.
+    /// `std::env::consts::ARCH` at the time the record was last written.
     pub arch: String,
     /// When this device first registered against this workspace.
+    /// Per-workspace and never rewritten.
     pub registered_at: DateTime<Utc>,
-    /// When any field was last updated.  Used to resolve cross-workspace
-    /// propagation of the editable fields (currently just `name`).
+    /// When any user-editable field was last updated.  Used to resolve
+    /// cross-workspace propagation of the editable fields (currently
+    /// just `name`).
     pub updated_at: DateTime<Utc>,
 }
 
-/// Machine-detected values supplied by the caller when registering a
-/// device for the first time, or when reconciling `client` /
-/// `client_version` on a subsequent open.
+/// Host-detected values supplied by the app at startup.  Used to seed
+/// the per-process [`DeviceContext`] and, through it, any workspace
+/// registry the app opens.
 #[derive(Clone, Debug)]
 pub struct DeviceDefaults {
-    /// Seed value for [`DeviceRecord::name`].  Usually the hostname.
+    /// System hostname; doubles as the initial value of the
+    /// `DeviceContext`'s editable `name`.
+    pub hostname: String,
+    /// Cargo package name of the running binary
+    /// (`env!("CARGO_PKG_NAME")`).
+    pub app_id: String,
+    /// Cargo package version of the running binary
+    /// (`env!("CARGO_PKG_VERSION")`).
+    pub app_version: String,
+    /// `std::env::consts::OS`.
+    pub platform: String,
+    /// `std::env::consts::ARCH`.
+    pub arch: String,
+}
+
+/// Process-wide, mutable device state held by the app.
+///
+/// The host-detected fields (`hostname` / `app_id` / `app_version` /
+/// `platform` / `arch`) come from [`DeviceDefaults`] and always win
+/// over a workspace registry's stored values — on merge we push them
+/// into the registry, not the other way round.
+///
+/// `name` and `updated_at` are the editable pair: the newer
+/// `updated_at` wins on merge.  `updated_at` is `None` until the
+/// context has either observed a workspace record or been explicitly
+/// renamed by the user; this "never touched" sentinel means any
+/// workspace-side timestamp wins the first merge.
+#[derive(Clone, Debug)]
+pub struct DeviceContext {
+    pub id: Uuid,
     pub name: String,
     pub hostname: String,
-    pub client: String,
-    pub client_version: String,
+    pub app_id: String,
+    pub app_version: String,
     pub platform: String,
     pub arch: String,
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+impl DeviceContext {
+    /// Combine a freshly loaded UUID with host defaults.  `name` is
+    /// seeded from `defaults.hostname`; `updated_at` starts `None`.
+    pub fn from_defaults(id: Uuid, defaults: DeviceDefaults) -> Self {
+        Self {
+            id,
+            name: defaults.hostname.clone(),
+            hostname: defaults.hostname,
+            app_id: defaults.app_id,
+            app_version: defaults.app_version,
+            platform: defaults.platform,
+            arch: defaults.arch,
+            updated_at: None,
+        }
+    }
+}
+
+/// Result of merging a [`DeviceContext`] into a [`DeviceRegistry`].
+#[derive(Clone, Debug)]
+pub struct MergeOutcome {
+    /// True iff the registry's in-memory records changed.  The caller
+    /// must [`save`](DeviceRegistry::save) and stage the file when this
+    /// is true.
+    pub changed: bool,
+    /// The merged record as it now stands in the registry.  The caller
+    /// should propagate `record.name` + `record.updated_at` back to the
+    /// app context when `record.updated_at` is newer than the context's.
+    pub record: DeviceRecord,
 }
 
 /// Registry of devices that have synced this workspace.
@@ -88,9 +150,7 @@ impl DeviceRegistry {
         let records = match fs::read_to_string(&path) {
             Ok(contents) => parse_jsonl(&path, &contents)?,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
-            Err(e) => {
-                return Err(Error::Io { path, source: e });
-            }
+            Err(e) => return Err(Error::Io { path, source: e }),
         };
         let mut this = Self { path, records };
         this.sort();
@@ -127,45 +187,68 @@ impl DeviceRegistry {
         &self.records
     }
 
-    /// Idempotent self-registration + lightweight reconciliation.
+    /// Merge the app-wide [`DeviceContext`] into this registry.
     ///
-    /// - No existing entry for `id`: append a fresh record populated
-    ///   from `defaults` with `registered_at == updated_at == now`.
-    ///   Returns `Ok(true)`.
-    /// - Existing entry whose `client` or `client_version` differs from
-    ///   `defaults`: overwrite just those two fields (and `updated_at`).
-    ///   This is the only "automatic" in-place update — every other
-    ///   field stays as originally registered.  Returns `Ok(true)`.
-    /// - Otherwise: leave the record alone, return `Ok(false)`.
+    /// - No existing entry for `ctx.id`: append a new record built from
+    ///   `ctx`.  `registered_at` is now.  `updated_at` is
+    ///   `ctx.updated_at.unwrap_or(now)` so a rename that already
+    ///   happened in another workspace (and propagated to the context)
+    ///   is preserved on this fresh registration.
+    /// - Existing entry: host-detected fields (`hostname` / `app_id` /
+    ///   `app_version` / `platform` / `arch`) are overwritten with the
+    ///   context's values — the running binary is the source of truth
+    ///   for facts about itself.  `name` + `updated_at` use whichever
+    ///   side has the newer `updated_at`.  `registered_at` is never
+    ///   touched.
     ///
-    /// The caller is expected to [`save`](Self::save) and stage the
-    /// file only when this returns `Ok(true)`.
-    pub fn ensure_registered(&mut self, id: Uuid, defaults: DeviceDefaults) -> Result<bool> {
+    /// Only the [`MergeOutcome::changed`] flag's "yes" case requires
+    /// saving and staging.
+    pub fn merge_device_context(&mut self, ctx: &DeviceContext) -> MergeOutcome {
         let now = Utc::now();
-        if let Some(existing) = self.records.iter_mut().find(|r| r.id == id) {
-            if existing.client == defaults.client
-                && existing.client_version == defaults.client_version
-            {
-                return Ok(false);
+        if let Some(existing) = self.records.iter_mut().find(|r| r.id == ctx.id) {
+            let host_changed = existing.hostname != ctx.hostname
+                || existing.app_id != ctx.app_id
+                || existing.app_version != ctx.app_version
+                || existing.platform != ctx.platform
+                || existing.arch != ctx.arch;
+            if host_changed {
+                existing.hostname = ctx.hostname.clone();
+                existing.app_id = ctx.app_id.clone();
+                existing.app_version = ctx.app_version.clone();
+                existing.platform = ctx.platform.clone();
+                existing.arch = ctx.arch.clone();
             }
-            existing.client = defaults.client;
-            existing.client_version = defaults.client_version;
-            existing.updated_at = now;
-            return Ok(true);
+            let ctx_wins_for_name = matches!(
+                ctx.updated_at,
+                Some(t) if t > existing.updated_at
+            );
+            if ctx_wins_for_name {
+                existing.name = ctx.name.clone();
+                existing.updated_at = ctx.updated_at.expect("just checked Some");
+            }
+            MergeOutcome {
+                changed: host_changed || ctx_wins_for_name,
+                record: existing.clone(),
+            }
+        } else {
+            let record = DeviceRecord {
+                id: ctx.id,
+                name: ctx.name.clone(),
+                hostname: ctx.hostname.clone(),
+                app_id: ctx.app_id.clone(),
+                app_version: ctx.app_version.clone(),
+                platform: ctx.platform.clone(),
+                arch: ctx.arch.clone(),
+                registered_at: now,
+                updated_at: ctx.updated_at.unwrap_or(now),
+            };
+            self.records.push(record.clone());
+            self.sort();
+            MergeOutcome {
+                changed: true,
+                record,
+            }
         }
-        self.records.push(DeviceRecord {
-            id,
-            name: defaults.name,
-            hostname: defaults.hostname,
-            client: defaults.client,
-            client_version: defaults.client_version,
-            platform: defaults.platform,
-            arch: defaults.arch,
-            registered_at: now,
-            updated_at: now,
-        });
-        self.sort();
-        Ok(true)
     }
 
     /// Update the human-readable name for `id` and bump `updated_at`.
@@ -240,15 +323,18 @@ fn parse_jsonl(path: &Path, contents: &str) -> Result<Vec<DeviceRecord>> {
 mod tests {
     use super::*;
 
-    fn defaults(name: &str) -> DeviceDefaults {
+    fn defaults(hostname: &str) -> DeviceDefaults {
         DeviceDefaults {
-            name: name.to_owned(),
-            hostname: name.to_owned(),
-            client: "sapphire-workspace-cli".to_owned(),
-            client_version: "0.9.0".to_owned(),
+            hostname: hostname.to_owned(),
+            app_id: "sapphire-workspace-cli".to_owned(),
+            app_version: "0.9.0".to_owned(),
             platform: "linux".to_owned(),
             arch: "x86_64".to_owned(),
         }
+    }
+
+    fn ctx(hostname: &str) -> DeviceContext {
+        DeviceContext::from_defaults(Uuid::now_v7(), defaults(hostname))
     }
 
     fn tmp_path(name: &str) -> PathBuf {
@@ -269,73 +355,140 @@ mod tests {
     }
 
     #[test]
-    fn ensure_registered_first_time_appends_with_matching_timestamps() {
+    fn merge_first_time_appends_new_record() {
         let path = tmp_path("first");
         let _ = fs::remove_file(&path);
         let mut registry = DeviceRegistry::load(&path).unwrap();
-        let id = Uuid::now_v7();
-        let added = registry.ensure_registered(id, defaults("my-host")).unwrap();
-        assert!(added);
-        let r = registry.lookup(id).unwrap();
+        let c = ctx("my-host");
+        let outcome = registry.merge_device_context(&c);
+        assert!(outcome.changed);
+        let r = registry.lookup(c.id).unwrap();
         assert_eq!(r.name, "my-host");
+        assert_eq!(r.hostname, "my-host");
+        assert_eq!(r.app_id, "sapphire-workspace-cli");
+        assert_eq!(r.app_version, "0.9.0");
+        // Fresh registration: context had None → record uses registered_at.
         assert_eq!(r.registered_at, r.updated_at);
     }
 
     #[test]
-    fn ensure_registered_is_idempotent() {
+    fn merge_first_time_preserves_context_updated_at() {
+        // A rename that happened in workspace A propagated into the
+        // context.  Opening workspace B for the first time should carry
+        // that timestamp over so subsequent merges don't oscillate.
+        let path = tmp_path("first-with-ts");
+        let _ = fs::remove_file(&path);
+        let mut registry = DeviceRegistry::load(&path).unwrap();
+        let mut c = ctx("host");
+        c.name = "renamed".into();
+        let t = Utc::now() - chrono::Duration::hours(1);
+        c.updated_at = Some(t);
+        let outcome = registry.merge_device_context(&c);
+        assert!(outcome.changed);
+        assert_eq!(outcome.record.name, "renamed");
+        assert_eq!(outcome.record.updated_at, t);
+    }
+
+    #[test]
+    fn merge_is_idempotent_on_unchanged_input() {
         let path = tmp_path("idem");
         let _ = fs::remove_file(&path);
         let mut registry = DeviceRegistry::load(&path).unwrap();
-        let id = Uuid::now_v7();
-        assert!(registry.ensure_registered(id, defaults("a")).unwrap());
-        let first_updated = registry.lookup(id).unwrap().updated_at;
-        // Sleep briefly so that if a bug writes Utc::now, the timestamp would differ.
+        let c = ctx("a");
+        assert!(registry.merge_device_context(&c).changed);
+        let before_updated = registry.lookup(c.id).unwrap().updated_at;
         std::thread::sleep(std::time::Duration::from_millis(5));
-        assert!(!registry.ensure_registered(id, defaults("a")).unwrap());
-        assert_eq!(registry.lookup(id).unwrap().updated_at, first_updated);
+        let second = registry.merge_device_context(&c);
+        assert!(!second.changed);
+        assert_eq!(registry.lookup(c.id).unwrap().updated_at, before_updated);
     }
 
     #[test]
-    fn ensure_registered_syncs_client_version_only() {
-        let path = tmp_path("cv");
+    fn merge_overwrites_host_fields_without_bumping_updated_at() {
+        let path = tmp_path("host-overwrite");
         let _ = fs::remove_file(&path);
         let mut registry = DeviceRegistry::load(&path).unwrap();
-        let id = Uuid::now_v7();
-        registry.ensure_registered(id, defaults("a")).unwrap();
-        let before = registry.lookup(id).unwrap().clone();
+        let c = ctx("host-a");
+        registry
+            .merge_device_context(&c)
+            .changed
+            .then_some(())
+            .unwrap();
+        let before = registry.lookup(c.id).unwrap().clone();
         std::thread::sleep(std::time::Duration::from_millis(5));
-        let mut new_defaults = defaults("ignored-name");
-        new_defaults.client_version = "1.0.0".to_owned();
-        new_defaults.hostname = "also-ignored".to_owned();
-        new_defaults.platform = "macos".to_owned();
-        new_defaults.arch = "aarch64".to_owned();
-        assert!(registry.ensure_registered(id, new_defaults).unwrap());
-        let after = registry.lookup(id).unwrap();
-        assert_eq!(after.client_version, "1.0.0");
-        // Unchanged fields:
+        let mut bumped = c.clone();
+        bumped.app_version = "2.0.0".into();
+        bumped.platform = "macos".into();
+        let outcome = registry.merge_device_context(&bumped);
+        assert!(outcome.changed);
+        let after = registry.lookup(c.id).unwrap();
+        assert_eq!(after.app_version, "2.0.0");
+        assert_eq!(after.platform, "macos");
+        // Host-only change must not bump updated_at.
+        assert_eq!(after.updated_at, before.updated_at);
+        // Name unchanged.
         assert_eq!(after.name, before.name);
-        assert_eq!(after.hostname, before.hostname);
-        assert_eq!(after.platform, before.platform);
-        assert_eq!(after.arch, before.arch);
-        assert_eq!(after.registered_at, before.registered_at);
-        assert!(after.updated_at > before.updated_at);
     }
 
     #[test]
-    fn ensure_registered_keeps_uuidv7_order() {
+    fn merge_context_wins_name_when_updated_at_newer() {
+        let path = tmp_path("ctx-wins");
+        let _ = fs::remove_file(&path);
+        let mut registry = DeviceRegistry::load(&path).unwrap();
+        let c = ctx("host");
+        registry.merge_device_context(&c);
+        let existing_updated = registry.lookup(c.id).unwrap().updated_at;
+
+        let mut c2 = c.clone();
+        c2.name = "ctx-name".into();
+        c2.updated_at = Some(existing_updated + chrono::Duration::seconds(10));
+        let outcome = registry.merge_device_context(&c2);
+        assert!(outcome.changed);
+        assert_eq!(registry.lookup(c.id).unwrap().name, "ctx-name");
+        assert_eq!(
+            registry.lookup(c.id).unwrap().updated_at,
+            c2.updated_at.unwrap()
+        );
+    }
+
+    #[test]
+    fn merge_record_wins_name_when_newer() {
+        let path = tmp_path("rec-wins");
+        let _ = fs::remove_file(&path);
+        let mut registry = DeviceRegistry::load(&path).unwrap();
+        let c = ctx("host");
+        registry.merge_device_context(&c);
+        registry.set_name(c.id, "record-name").unwrap();
+        let record_updated = registry.lookup(c.id).unwrap().updated_at;
+
+        let mut c2 = c.clone();
+        c2.name = "stale-ctx-name".into();
+        c2.updated_at = Some(record_updated - chrono::Duration::seconds(10));
+        let outcome = registry.merge_device_context(&c2);
+        // Host fields match, name-wise record wins → no change at all.
+        assert!(!outcome.changed);
+        assert_eq!(registry.lookup(c.id).unwrap().name, "record-name");
+    }
+
+    #[test]
+    fn merge_keeps_uuidv7_order() {
         let path = tmp_path("order");
         let _ = fs::remove_file(&path);
         let mut registry = DeviceRegistry::load(&path).unwrap();
-        let a = Uuid::now_v7();
+        let a_id = Uuid::now_v7();
         std::thread::sleep(std::time::Duration::from_millis(5));
-        let b = Uuid::now_v7();
-        // Register in reversed order — storage should still be UUIDv7 ascending.
-        registry.ensure_registered(b, defaults("b")).unwrap();
-        registry.ensure_registered(a, defaults("a")).unwrap();
+        let b_id = Uuid::now_v7();
+        let mut b = ctx("b");
+        b.id = b_id;
+        let mut a = ctx("a");
+        a.id = a_id;
+        // Insert in reverse order — storage should still be UUIDv7 ascending.
+        registry.merge_device_context(&b);
+        registry.merge_device_context(&a);
         let ids: Vec<Uuid> = registry.records().iter().map(|r| r.id).collect();
-        assert_eq!(ids, vec![a, b]);
-        assert_eq!(registry.device_number(a), Some(1));
-        assert_eq!(registry.device_number(b), Some(2));
+        assert_eq!(ids, vec![a_id, b_id]);
+        assert_eq!(registry.device_number(a_id), Some(1));
+        assert_eq!(registry.device_number(b_id), Some(2));
     }
 
     #[test]
@@ -343,8 +496,7 @@ mod tests {
         let path = tmp_path("rt");
         let _ = fs::remove_file(&path);
         let mut registry = DeviceRegistry::load(&path).unwrap();
-        let id = Uuid::now_v7();
-        registry.ensure_registered(id, defaults("round")).unwrap();
+        registry.merge_device_context(&ctx("round"));
         registry.save().unwrap();
 
         let reloaded = DeviceRegistry::load(&path).unwrap();
@@ -356,18 +508,18 @@ mod tests {
         let path = tmp_path("setname");
         let _ = fs::remove_file(&path);
         let mut registry = DeviceRegistry::load(&path).unwrap();
-        let id = Uuid::now_v7();
-        registry.ensure_registered(id, defaults("seed")).unwrap();
-        let before = registry.lookup(id).unwrap().clone();
+        let c = ctx("seed");
+        registry.merge_device_context(&c);
+        let before = registry.lookup(c.id).unwrap().clone();
         std::thread::sleep(std::time::Duration::from_millis(5));
-        registry.set_name(id, "alice-laptop").unwrap();
-        let after = registry.lookup(id).unwrap();
+        registry.set_name(c.id, "alice-laptop").unwrap();
+        let after = registry.lookup(c.id).unwrap();
         assert_eq!(after.name, "alice-laptop");
         assert_eq!(after.id, before.id);
         assert_eq!(after.registered_at, before.registered_at);
         assert_eq!(after.hostname, before.hostname);
-        assert_eq!(after.client, before.client);
-        assert_eq!(after.client_version, before.client_version);
+        assert_eq!(after.app_id, before.app_id);
+        assert_eq!(after.app_version, before.app_version);
         assert_eq!(after.platform, before.platform);
         assert_eq!(after.arch, before.arch);
         assert!(after.updated_at > before.updated_at);
@@ -385,21 +537,21 @@ mod tests {
         let path = tmp_path("newer");
         let _ = fs::remove_file(&path);
         let mut registry = DeviceRegistry::load(&path).unwrap();
-        let id = Uuid::now_v7();
-        registry.ensure_registered(id, defaults("old")).unwrap();
+        let c = ctx("old");
+        registry.merge_device_context(&c);
 
-        let mut incoming = registry.lookup(id).unwrap().clone();
+        let mut incoming = registry.lookup(c.id).unwrap().clone();
         incoming.name = "old-but-older".to_owned();
         incoming.updated_at =
-            registry.lookup(id).unwrap().updated_at - chrono::Duration::seconds(10);
+            registry.lookup(c.id).unwrap().updated_at - chrono::Duration::seconds(10);
         assert!(!registry.update_if_newer(incoming).unwrap());
-        assert_ne!(registry.lookup(id).unwrap().name, "old-but-older");
+        assert_ne!(registry.lookup(c.id).unwrap().name, "old-but-older");
 
-        let mut fresh = registry.lookup(id).unwrap().clone();
+        let mut fresh = registry.lookup(c.id).unwrap().clone();
         fresh.name = "winner".to_owned();
         fresh.updated_at = Utc::now() + chrono::Duration::seconds(1);
         assert!(registry.update_if_newer(fresh).unwrap());
-        assert_eq!(registry.lookup(id).unwrap().name, "winner");
+        assert_eq!(registry.lookup(c.id).unwrap().name, "winner");
     }
 
     #[test]

--- a/crates/sapphire-sync/src/error.rs
+++ b/crates/sapphire-sync/src/error.rs
@@ -16,6 +16,24 @@ pub enum Error {
     #[error("remote '{name}' not found")]
     RemoteNotFound { name: String },
 
+    #[error("device record for id '{id}' not found in registry")]
+    DeviceNotFound { id: uuid::Uuid },
+
+    #[error("I/O error at '{path}': {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("malformed device record at '{path}' line {line}: {source}")]
+    DeviceRecordParse {
+        path: PathBuf,
+        line: usize,
+        #[source]
+        source: serde_json::Error,
+    },
+
     #[cfg(feature = "git")]
     #[error(transparent)]
     Git(#[from] git2::Error),

--- a/crates/sapphire-sync/src/lib.rs
+++ b/crates/sapphire-sync/src/lib.rs
@@ -1,8 +1,10 @@
 use std::path::Path;
 
 pub mod config;
+pub mod devices;
 mod error;
 pub use config::{SyncBackendKind, SyncConfig};
+pub use devices::{DeviceDefaults, DeviceRecord, DeviceRegistry};
 pub use error::{Error, Result};
 
 #[cfg(feature = "git")]

--- a/crates/sapphire-sync/src/lib.rs
+++ b/crates/sapphire-sync/src/lib.rs
@@ -4,7 +4,7 @@ pub mod config;
 pub mod devices;
 mod error;
 pub use config::{SyncBackendKind, SyncConfig};
-pub use devices::{DeviceDefaults, DeviceRecord, DeviceRegistry};
+pub use devices::{DeviceContext, DeviceDefaults, DeviceRecord, DeviceRegistry, MergeOutcome};
 pub use error::{Error, Result};
 
 #[cfg(feature = "git")]

--- a/crates/sapphire-workspace-cli/Cargo.toml
+++ b/crates/sapphire-workspace-cli/Cargo.toml
@@ -35,3 +35,5 @@ config = { version = "0.15", default-features = false, features = ["toml"] }
 dirs = "6"
 toml.workspace = true
 uuid.workspace = true
+chrono = { workspace = true }
+hostname = "0.4"

--- a/crates/sapphire-workspace-cli/src/commands/delete.rs
+++ b/crates/sapphire-workspace-cli/src/commands/delete.rs
@@ -3,13 +3,16 @@ use std::path::Path;
 use anyhow::Result;
 use sapphire_workspace::WorkspaceState;
 
-use crate::commands::sync::open_workspace;
+use crate::commands::sync::{collect_device_defaults, open_workspace, resolve_device_id};
 
 pub fn run(workspace_dir: Option<&Path>, path: &Path) -> Result<()> {
+    let device_id = resolve_device_id();
+    let defaults = collect_device_defaults();
+
     let (workspace, config) = open_workspace(workspace_dir)?;
 
-    // Staging-only command: no commits are produced, so no device id needed.
-    let state = WorkspaceState::open_configured(workspace, &config.sync, None)?;
+    let state =
+        WorkspaceState::open_configured(workspace, &config.sync, device_id, Some(defaults))?;
 
     let abs_path = if path.is_absolute() {
         path.to_owned()

--- a/crates/sapphire-workspace-cli/src/commands/delete.rs
+++ b/crates/sapphire-workspace-cli/src/commands/delete.rs
@@ -3,16 +3,12 @@ use std::path::Path;
 use anyhow::Result;
 use sapphire_workspace::WorkspaceState;
 
-use crate::commands::sync::{collect_device_defaults, open_workspace, resolve_device_id};
+use crate::commands::sync::open_workspace;
 
 pub fn run(workspace_dir: Option<&Path>, path: &Path) -> Result<()> {
-    let device_id = resolve_device_id();
-    let defaults = collect_device_defaults();
-
     let (workspace, config) = open_workspace(workspace_dir)?;
 
-    let state =
-        WorkspaceState::open_configured(workspace, &config.sync, device_id, Some(defaults))?;
+    let state = WorkspaceState::open_configured(workspace, &config.sync)?;
 
     let abs_path = if path.is_absolute() {
         path.to_owned()

--- a/crates/sapphire-workspace-cli/src/commands/device.rs
+++ b/crates/sapphire-workspace-cli/src/commands/device.rs
@@ -1,0 +1,174 @@
+use std::path::Path;
+
+use anyhow::{Result, bail};
+use clap::Subcommand;
+use sapphire_workspace::{DeviceRecord, DeviceRegistry, WorkspaceState};
+use uuid::Uuid;
+
+use crate::WORKSPACE_CTX;
+use crate::commands::sync::{collect_device_defaults, open_workspace, resolve_device_id};
+
+#[derive(Subcommand)]
+pub enum DeviceCommand {
+    /// Show all registered devices, one per line, in UUIDv7 order.
+    List,
+    /// Update this device's human-readable name.
+    SetName {
+        /// New name (stored in the `name` field).
+        name: String,
+    },
+    /// Print full record for a device.  Argument is a UUID or a 1-based
+    /// Device Number from `device list`.  Omit to show this device.
+    Show {
+        /// Device UUID or Device Number.
+        target: Option<String>,
+    },
+}
+
+pub fn run(workspace_dir: Option<&Path>, cmd: &DeviceCommand) -> Result<()> {
+    match cmd {
+        DeviceCommand::List => run_list(workspace_dir),
+        DeviceCommand::SetName { name } => run_set_name(workspace_dir, name),
+        DeviceCommand::Show { target } => run_show(workspace_dir, target.as_deref()),
+    }
+}
+
+fn run_list(workspace_dir: Option<&Path>) -> Result<()> {
+    let registry = open_registry(workspace_dir)?;
+    let self_id = WORKSPACE_CTX.device_id().ok();
+    if registry.records().is_empty() {
+        println!("(no devices registered)");
+        return Ok(());
+    }
+    println!(
+        " {:>2}  {:36}  {:20}  {:24}  {:8}  {}",
+        "#", "id", "name", "client", "platform", "updated_at"
+    );
+    for (i, r) in registry.records().iter().enumerate() {
+        let marker = if Some(r.id) == self_id { "*" } else { " " };
+        let client = format!("{} {}", r.client, r.client_version);
+        println!(
+            "{}{:>2}  {:36}  {:20}  {:24}  {:8}  {}",
+            marker,
+            i + 1,
+            r.id,
+            truncate(&r.name, 20),
+            truncate(&client, 24),
+            truncate(&r.platform, 8),
+            r.updated_at.format("%Y-%m-%d %H:%M:%SZ"),
+        );
+    }
+    Ok(())
+}
+
+fn run_set_name(workspace_dir: Option<&Path>, name: &str) -> Result<()> {
+    let self_id = match resolve_device_id() {
+        Some(id) => id,
+        None => bail!("cannot determine this device's id"),
+    };
+
+    // Open via open_configured so the sync backend is wired up — we use it
+    // to stage the modified file after saving.  open_configured also runs
+    // idempotent self-registration, which seeds the entry we are about to
+    // rename if this is the first run.
+    let defaults = collect_device_defaults();
+    let (workspace, config) = open_workspace(workspace_dir)?;
+    let marker_dir = workspace.marker_dir();
+    let state =
+        WorkspaceState::open_configured(workspace, &config.sync, Some(self_id), Some(defaults))?;
+
+    let path = marker_dir.join("devices.jsonl");
+    let mut registry = DeviceRegistry::load(&path)?;
+    registry.set_name(self_id, name)?;
+    registry.save()?;
+    if let Some(backend) = state.sync_backend() {
+        backend.add_file(&path)?;
+    }
+    println!("device name updated to '{name}' (id: {self_id})");
+    println!("next `sync` will commit and push this change");
+    Ok(())
+}
+
+fn run_show(workspace_dir: Option<&Path>, target: Option<&str>) -> Result<()> {
+    let registry = open_registry(workspace_dir)?;
+    let self_id = WORKSPACE_CTX.device_id().ok();
+
+    let (record, number) = match target {
+        None => {
+            let id = self_id.ok_or_else(|| anyhow::anyhow!("cannot determine this device's id"))?;
+            let r = registry
+                .lookup(id)
+                .ok_or_else(|| anyhow::anyhow!("this device is not registered yet"))?;
+            let n = registry.device_number(id).unwrap_or(0);
+            (r, n)
+        }
+        Some(arg) => resolve_target(&registry, arg)?,
+    };
+
+    println!("device number:  {number}");
+    println!("id:             {}", record.id);
+    println!("name:           {}", record.name);
+    println!("hostname:       {}", record.hostname);
+    println!(
+        "client:         {} {}",
+        record.client, record.client_version
+    );
+    println!("platform:       {} / {}", record.platform, record.arch);
+    println!("registered_at:  {}", record.registered_at.to_rfc3339());
+    println!("updated_at:     {}", record.updated_at.to_rfc3339());
+    if Some(record.id) == self_id {
+        println!("(this device)");
+    }
+    Ok(())
+}
+
+fn resolve_target<'a>(
+    registry: &'a DeviceRegistry,
+    arg: &str,
+) -> Result<(&'a DeviceRecord, usize)> {
+    // Try Device Number first — UUID strings always contain hyphens, so a
+    // bare integer is unambiguously a number.
+    if let Ok(n) = arg.parse::<usize>() {
+        if n == 0 || n > registry.records().len() {
+            bail!(
+                "device number {n} out of range (1..={})",
+                registry.records().len()
+            );
+        }
+        let record = &registry.records()[n - 1];
+        return Ok((record, n));
+    }
+    let id: Uuid = arg
+        .parse()
+        .map_err(|e| anyhow::anyhow!("'{arg}' is neither a UUID nor a device number: {e}"))?;
+    let record = registry
+        .lookup(id)
+        .ok_or_else(|| anyhow::anyhow!("no device with id {id} in registry"))?;
+    let number = registry.device_number(id).unwrap_or(0);
+    Ok((record, number))
+}
+
+/// Open the registry via `open_configured` so that idempotent
+/// self-registration and the `client` / `client_version`
+/// auto-reconciliation run before the caller reads any records — even
+/// for read-only inspection commands like `device list` / `device show`.
+fn open_registry(workspace_dir: Option<&Path>) -> Result<DeviceRegistry> {
+    let device_id = resolve_device_id();
+    let defaults = collect_device_defaults();
+    let (workspace, config) = open_workspace(workspace_dir)?;
+    let marker_dir = workspace.marker_dir();
+    let _state =
+        WorkspaceState::open_configured(workspace, &config.sync, device_id, Some(defaults))?;
+    let path = marker_dir.join("devices.jsonl");
+    Ok(DeviceRegistry::load(path)?)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_owned()
+    } else {
+        let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+        out.push('…');
+        out
+    }
+}

--- a/crates/sapphire-workspace-cli/src/commands/device.rs
+++ b/crates/sapphire-workspace-cli/src/commands/device.rs
@@ -6,7 +6,7 @@ use sapphire_workspace::{DeviceRecord, DeviceRegistry, WorkspaceState};
 use uuid::Uuid;
 
 use crate::WORKSPACE_CTX;
-use crate::commands::sync::{collect_device_defaults, open_workspace, resolve_device_id};
+use crate::commands::sync::open_workspace;
 
 #[derive(Subcommand)]
 pub enum DeviceCommand {
@@ -35,25 +35,25 @@ pub fn run(workspace_dir: Option<&Path>, cmd: &DeviceCommand) -> Result<()> {
 
 fn run_list(workspace_dir: Option<&Path>) -> Result<()> {
     let registry = open_registry(workspace_dir)?;
-    let self_id = WORKSPACE_CTX.device_id().ok();
+    let self_id = WORKSPACE_CTX.device_id();
     if registry.records().is_empty() {
         println!("(no devices registered)");
         return Ok(());
     }
     println!(
         " {:>2}  {:36}  {:20}  {:24}  {:8}  {}",
-        "#", "id", "name", "client", "platform", "updated_at"
+        "#", "id", "name", "app", "platform", "updated_at"
     );
     for (i, r) in registry.records().iter().enumerate() {
         let marker = if Some(r.id) == self_id { "*" } else { " " };
-        let client = format!("{} {}", r.client, r.client_version);
+        let app = format!("{} {}", r.app_id, r.app_version);
         println!(
             "{}{:>2}  {:36}  {:20}  {:24}  {:8}  {}",
             marker,
             i + 1,
             r.id,
             truncate(&r.name, 20),
-            truncate(&client, 24),
+            truncate(&app, 24),
             truncate(&r.platform, 8),
             r.updated_at.format("%Y-%m-%d %H:%M:%SZ"),
         );
@@ -62,36 +62,22 @@ fn run_list(workspace_dir: Option<&Path>) -> Result<()> {
 }
 
 fn run_set_name(workspace_dir: Option<&Path>, name: &str) -> Result<()> {
-    let self_id = match resolve_device_id() {
-        Some(id) => id,
-        None => bail!("cannot determine this device's id"),
-    };
-
-    // Open via open_configured so the sync backend is wired up — we use it
-    // to stage the modified file after saving.  open_configured also runs
-    // idempotent self-registration, which seeds the entry we are about to
-    // rename if this is the first run.
-    let defaults = collect_device_defaults();
     let (workspace, config) = open_workspace(workspace_dir)?;
-    let marker_dir = workspace.marker_dir();
-    let state =
-        WorkspaceState::open_configured(workspace, &config.sync, Some(self_id), Some(defaults))?;
-
-    let path = marker_dir.join("devices.jsonl");
-    let mut registry = DeviceRegistry::load(&path)?;
-    registry.set_name(self_id, name)?;
-    registry.save()?;
-    if let Some(backend) = state.sync_backend() {
-        backend.add_file(&path)?;
+    let state = WorkspaceState::open_configured(workspace, &config.sync)?;
+    state.rename_device(name)?;
+    let id = WORKSPACE_CTX.device_id();
+    if let Some(id) = id {
+        println!("device name updated to '{name}' (id: {id})");
+    } else {
+        println!("device name updated to '{name}'");
     }
-    println!("device name updated to '{name}' (id: {self_id})");
     println!("next `sync` will commit and push this change");
     Ok(())
 }
 
 fn run_show(workspace_dir: Option<&Path>, target: Option<&str>) -> Result<()> {
     let registry = open_registry(workspace_dir)?;
-    let self_id = WORKSPACE_CTX.device_id().ok();
+    let self_id = WORKSPACE_CTX.device_id();
 
     let (record, number) = match target {
         None => {
@@ -109,10 +95,7 @@ fn run_show(workspace_dir: Option<&Path>, target: Option<&str>) -> Result<()> {
     println!("id:             {}", record.id);
     println!("name:           {}", record.name);
     println!("hostname:       {}", record.hostname);
-    println!(
-        "client:         {} {}",
-        record.client, record.client_version
-    );
+    println!("app:            {} {}", record.app_id, record.app_version);
     println!("platform:       {} / {}", record.platform, record.arch);
     println!("registered_at:  {}", record.registered_at.to_rfc3339());
     println!("updated_at:     {}", record.updated_at.to_rfc3339());
@@ -148,17 +131,14 @@ fn resolve_target<'a>(
     Ok((record, number))
 }
 
-/// Open the registry via `open_configured` so that idempotent
-/// self-registration and the `client` / `client_version`
-/// auto-reconciliation run before the caller reads any records — even
-/// for read-only inspection commands like `device list` / `device show`.
+/// Open the registry via `open_configured` so that the merge-on-open
+/// flow (idempotent self-registration + host-field reconciliation)
+/// runs before the caller reads any records — even for read-only
+/// inspection commands.
 fn open_registry(workspace_dir: Option<&Path>) -> Result<DeviceRegistry> {
-    let device_id = resolve_device_id();
-    let defaults = collect_device_defaults();
     let (workspace, config) = open_workspace(workspace_dir)?;
     let marker_dir = workspace.marker_dir();
-    let _state =
-        WorkspaceState::open_configured(workspace, &config.sync, device_id, Some(defaults))?;
+    let _state = WorkspaceState::open_configured(workspace, &config.sync)?;
     let path = marker_dir.join("devices.jsonl");
     Ok(DeviceRegistry::load(path)?)
 }

--- a/crates/sapphire-workspace-cli/src/commands/mod.rs
+++ b/crates/sapphire-workspace-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod cache;
 pub mod delete;
+pub mod device;
 pub mod init;
 pub mod sync;
 pub mod upsert;

--- a/crates/sapphire-workspace-cli/src/commands/sync.rs
+++ b/crates/sapphire-workspace-cli/src/commands/sync.rs
@@ -1,19 +1,14 @@
 use std::path::Path;
 
 use anyhow::{Result, bail};
-use sapphire_workspace::{DeviceDefaults, WorkspaceState, workspace::Workspace};
-
-use crate::config::UserConfig;
+use sapphire_workspace::{WorkspaceState, workspace::Workspace};
 
 use crate::WORKSPACE_CTX;
+use crate::config::UserConfig;
 
 pub fn run(workspace_dir: Option<&Path>) -> Result<()> {
-    let device_id = resolve_device_id();
-    let defaults = collect_device_defaults();
-
     let (workspace, config) = open_workspace(workspace_dir)?;
-    let state =
-        WorkspaceState::open_configured(workspace, &config.sync, device_id, Some(defaults))?;
+    let state = WorkspaceState::open_configured(workspace, &config.sync)?;
 
     let Some(backend) = state.sync_backend() else {
         bail!(
@@ -44,34 +39,4 @@ pub fn open_workspace(explicit: Option<&Path>) -> Result<(Workspace, UserConfig)
 
     let config = crate::config::load_user_config()?;
     Ok((workspace, config))
-}
-
-/// Load (or lazily create) the persistent device id.  Log + demote to
-/// `None` on IO errors so the CLI still runs — commits will just be
-/// unattributed.
-pub fn resolve_device_id() -> Option<uuid::Uuid> {
-    match WORKSPACE_CTX.device_id() {
-        Ok(id) => Some(id),
-        Err(e) => {
-            tracing::error!("could not persist device_id: {e}");
-            None
-        }
-    }
-}
-
-/// Collect the machine-detected defaults the CLI supplies on first
-/// device registration (and for client-version reconciliation).
-pub fn collect_device_defaults() -> DeviceDefaults {
-    let hostname = hostname::get()
-        .ok()
-        .and_then(|s| s.into_string().ok())
-        .unwrap_or_default();
-    DeviceDefaults {
-        name: hostname.clone(),
-        hostname,
-        client: env!("CARGO_PKG_NAME").to_owned(),
-        client_version: env!("CARGO_PKG_VERSION").to_owned(),
-        platform: std::env::consts::OS.to_owned(),
-        arch: std::env::consts::ARCH.to_owned(),
-    }
 }

--- a/crates/sapphire-workspace-cli/src/commands/sync.rs
+++ b/crates/sapphire-workspace-cli/src/commands/sync.rs
@@ -1,23 +1,19 @@
 use std::path::Path;
 
 use anyhow::{Result, bail};
-use sapphire_workspace::{WorkspaceState, workspace::Workspace};
+use sapphire_workspace::{DeviceDefaults, WorkspaceState, workspace::Workspace};
 
 use crate::config::UserConfig;
 
 use crate::WORKSPACE_CTX;
 
 pub fn run(workspace_dir: Option<&Path>) -> Result<()> {
-    let device_id = match WORKSPACE_CTX.device_id() {
-        Ok(id) => Some(id),
-        Err(e) => {
-            tracing::error!("could not persist device_id: {e}");
-            None
-        }
-    };
+    let device_id = resolve_device_id();
+    let defaults = collect_device_defaults();
 
     let (workspace, config) = open_workspace(workspace_dir)?;
-    let state = WorkspaceState::open_configured(workspace, &config.sync, device_id)?;
+    let state =
+        WorkspaceState::open_configured(workspace, &config.sync, device_id, Some(defaults))?;
 
     let Some(backend) = state.sync_backend() else {
         bail!(
@@ -48,4 +44,34 @@ pub fn open_workspace(explicit: Option<&Path>) -> Result<(Workspace, UserConfig)
 
     let config = crate::config::load_user_config()?;
     Ok((workspace, config))
+}
+
+/// Load (or lazily create) the persistent device id.  Log + demote to
+/// `None` on IO errors so the CLI still runs — commits will just be
+/// unattributed.
+pub fn resolve_device_id() -> Option<uuid::Uuid> {
+    match WORKSPACE_CTX.device_id() {
+        Ok(id) => Some(id),
+        Err(e) => {
+            tracing::error!("could not persist device_id: {e}");
+            None
+        }
+    }
+}
+
+/// Collect the machine-detected defaults the CLI supplies on first
+/// device registration (and for client-version reconciliation).
+pub fn collect_device_defaults() -> DeviceDefaults {
+    let hostname = hostname::get()
+        .ok()
+        .and_then(|s| s.into_string().ok())
+        .unwrap_or_default();
+    DeviceDefaults {
+        name: hostname.clone(),
+        hostname,
+        client: env!("CARGO_PKG_NAME").to_owned(),
+        client_version: env!("CARGO_PKG_VERSION").to_owned(),
+        platform: std::env::consts::OS.to_owned(),
+        arch: std::env::consts::ARCH.to_owned(),
+    }
 }

--- a/crates/sapphire-workspace-cli/src/commands/upsert.rs
+++ b/crates/sapphire-workspace-cli/src/commands/upsert.rs
@@ -3,13 +3,16 @@ use std::path::Path;
 use anyhow::Result;
 use sapphire_workspace::WorkspaceState;
 
-use crate::commands::sync::open_workspace;
+use crate::commands::sync::{collect_device_defaults, open_workspace, resolve_device_id};
 
 pub fn run(workspace_dir: Option<&Path>, path: &Path) -> Result<()> {
+    let device_id = resolve_device_id();
+    let defaults = collect_device_defaults();
+
     let (workspace, config) = open_workspace(workspace_dir)?;
 
-    // Staging-only command: no commits are produced, so no device id needed.
-    let state = WorkspaceState::open_configured(workspace, &config.sync, None)?;
+    let state =
+        WorkspaceState::open_configured(workspace, &config.sync, device_id, Some(defaults))?;
 
     let abs_path = if path.is_absolute() {
         path.to_owned()

--- a/crates/sapphire-workspace-cli/src/commands/upsert.rs
+++ b/crates/sapphire-workspace-cli/src/commands/upsert.rs
@@ -3,16 +3,12 @@ use std::path::Path;
 use anyhow::Result;
 use sapphire_workspace::WorkspaceState;
 
-use crate::commands::sync::{collect_device_defaults, open_workspace, resolve_device_id};
+use crate::commands::sync::open_workspace;
 
 pub fn run(workspace_dir: Option<&Path>, path: &Path) -> Result<()> {
-    let device_id = resolve_device_id();
-    let defaults = collect_device_defaults();
-
     let (workspace, config) = open_workspace(workspace_dir)?;
 
-    let state =
-        WorkspaceState::open_configured(workspace, &config.sync, device_id, Some(defaults))?;
+    let state = WorkspaceState::open_configured(workspace, &config.sync)?;
 
     let abs_path = if path.is_absolute() {
         path.to_owned()

--- a/crates/sapphire-workspace-cli/src/commands/watch.rs
+++ b/crates/sapphire-workspace-cli/src/commands/watch.rs
@@ -6,17 +6,11 @@ use anyhow::Result;
 use notify_debouncer_mini::{DebounceEventResult, Debouncer, new_debouncer, notify};
 use sapphire_workspace::WorkspaceState;
 
-use crate::WORKSPACE_CTX;
-use crate::commands::sync::open_workspace;
+use crate::commands::sync::{collect_device_defaults, open_workspace, resolve_device_id};
 
 pub fn run(workspace_dir: Option<&Path>, debounce_ms: u64) -> Result<()> {
-    let device_id = match WORKSPACE_CTX.device_id() {
-        Ok(id) => Some(id),
-        Err(e) => {
-            tracing::error!("could not persist device_id: {e}");
-            None
-        }
-    };
+    let device_id = resolve_device_id();
+    let defaults = collect_device_defaults();
 
     let (workspace, config) = open_workspace(workspace_dir)?;
 
@@ -27,6 +21,7 @@ pub fn run(workspace_dir: Option<&Path>, debounce_ms: u64) -> Result<()> {
         workspace,
         &config.sync,
         device_id,
+        Some(defaults),
     )?);
 
     println!("watching: {}", watch_root.display());

--- a/crates/sapphire-workspace-cli/src/commands/watch.rs
+++ b/crates/sapphire-workspace-cli/src/commands/watch.rs
@@ -6,23 +6,15 @@ use anyhow::Result;
 use notify_debouncer_mini::{DebounceEventResult, Debouncer, new_debouncer, notify};
 use sapphire_workspace::WorkspaceState;
 
-use crate::commands::sync::{collect_device_defaults, open_workspace, resolve_device_id};
+use crate::commands::sync::open_workspace;
 
 pub fn run(workspace_dir: Option<&Path>, debounce_ms: u64) -> Result<()> {
-    let device_id = resolve_device_id();
-    let defaults = collect_device_defaults();
-
     let (workspace, config) = open_workspace(workspace_dir)?;
 
     let watch_root = workspace.root.clone();
     let sync_interval = config.sync_interval();
 
-    let state = Arc::new(WorkspaceState::open_configured(
-        workspace,
-        &config.sync,
-        device_id,
-        Some(defaults),
-    )?);
+    let state = Arc::new(WorkspaceState::open_configured(workspace, &config.sync)?);
 
     println!("watching: {}", watch_root.display());
     if let Some(interval) = sync_interval {

--- a/crates/sapphire-workspace-cli/src/main.rs
+++ b/crates/sapphire-workspace-cli/src/main.rs
@@ -94,6 +94,12 @@ enum Command {
         action: CacheCommand,
     },
 
+    /// Inspect and rename devices tracked in this workspace
+    Device {
+        #[command(subcommand)]
+        action: commands::device::DeviceCommand,
+    },
+
     /// Start the MCP server (stdio transport)
     Mcp,
 }
@@ -132,6 +138,7 @@ fn main() -> anyhow::Result<()> {
             CacheCommand::Embed => commands::cache::embed::run(workspace_dir)?,
             CacheCommand::Clean => commands::cache::clean::run(workspace_dir)?,
         },
+        Command::Device { action } => commands::device::run(workspace_dir, &action)?,
         Command::Mcp => mcp::run(workspace_dir)?,
     }
     Ok(())

--- a/crates/sapphire-workspace-cli/src/main.rs
+++ b/crates/sapphire-workspace-cli/src/main.rs
@@ -4,13 +4,14 @@ mod mcp;
 
 use std::path::PathBuf;
 
-use sapphire_workspace::AppContext;
+use sapphire_workspace::{AppContext, DeviceDefaults};
 
 pub static WORKSPACE_CTX: AppContext = AppContext::new("sapphire-workspace");
 
-/// Resolve and inject the host platform's cache and data directories into
-/// [`WORKSPACE_CTX`].  The library deliberately does not depend on `dirs`,
-/// so the CLI must do this once at startup.
+/// Resolve and inject the host platform's cache and data directories,
+/// plus host-detected device facts, into [`WORKSPACE_CTX`].  The
+/// library deliberately does not depend on `dirs` or `hostname`, so the
+/// CLI must do this once at startup.
 fn init_workspace_ctx() {
     let cache_dir = dirs::cache_dir()
         .unwrap_or_else(std::env::temp_dir)
@@ -20,6 +21,21 @@ fn init_workspace_ctx() {
         .join(WORKSPACE_CTX.app_name);
     WORKSPACE_CTX.set_cache_dir(cache_dir);
     WORKSPACE_CTX.set_data_dir(data_dir);
+    WORKSPACE_CTX.set_device_defaults(collect_device_defaults());
+}
+
+fn collect_device_defaults() -> DeviceDefaults {
+    let hostname = hostname::get()
+        .ok()
+        .and_then(|s| s.into_string().ok())
+        .unwrap_or_default();
+    DeviceDefaults {
+        hostname,
+        app_id: env!("CARGO_PKG_NAME").to_owned(),
+        app_version: env!("CARGO_PKG_VERSION").to_owned(),
+        platform: std::env::consts::OS.to_owned(),
+        arch: std::env::consts::ARCH.to_owned(),
+    }
 }
 
 /// Install a stderr tracing subscriber for the whole CLI, so

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 
+use chrono::{DateTime, Utc};
+use sapphire_sync::{DeviceContext, DeviceDefaults};
 use uuid::Uuid;
 
 use crate::error::Result;
@@ -8,34 +10,51 @@ use crate::workspace::path_uuid;
 
 /// Application-wide context shared across all [`Workspace`](crate::Workspace) instances.
 ///
-/// Holds the `app_name` (used for the marker directory) and the cache /
-/// data directories.  This crate intentionally does **not** depend on
-/// platform path crates (e.g. `dirs`); the host application is expected to
-/// resolve the correct directories for its target and inject them via
-/// [`set_cache_dir`](Self::set_cache_dir) and [`set_data_dir`](Self::set_data_dir)
-/// at startup.  This keeps the library portable to mobile sandboxes where
-/// the platform APIs differ.
+/// Holds the `app_name` (used for the marker directory), cache / data
+/// directories, and the per-process [`DeviceContext`].  The device
+/// context caches the UUIDv7 device id plus host-detected facts
+/// (hostname, running binary, OS, arch) and tracks the latest observed
+/// `updated_at` for the user-editable device name so the host app can
+/// propagate renames between workspaces opened in the same process.
+///
+/// This crate intentionally does **not** depend on platform path
+/// crates (e.g. `dirs`) or on host-detection crates (e.g. `hostname`);
+/// the host application is expected to resolve the correct directories
+/// and gather host facts for its target, then inject them via
+/// [`set_cache_dir`](Self::set_cache_dir) /
+/// [`set_data_dir`](Self::set_data_dir) /
+/// [`set_device_defaults`](Self::set_device_defaults) at startup.
 ///
 /// # Usage
 ///
-/// Declare a `static` instance in your application crate, then initialise
-/// the directories before opening any workspace:
+/// Declare a `static` instance in your application crate, then
+/// initialise the directories and device defaults before opening any
+/// workspace:
 ///
 /// ```rust,ignore
-/// use sapphire_workspace::AppContext;
+/// use sapphire_workspace::{AppContext, DeviceDefaults};
 ///
 /// pub static MY_CTX: AppContext = AppContext::new("my-app");
 ///
 /// fn main() {
-///     MY_CTX.set_cache_dir(host_cache_dir);   // e.g. dirs::cache_dir()/my-app
-///     MY_CTX.set_data_dir(host_data_dir);     // e.g. dirs::data_dir()/my-app
+///     MY_CTX.set_cache_dir(host_cache_dir);
+///     MY_CTX.set_data_dir(host_data_dir);
+///     MY_CTX.set_device_defaults(DeviceDefaults {
+///         hostname: hostname::get().unwrap().to_string_lossy().into(),
+///         app_id: env!("CARGO_PKG_NAME").to_owned(),
+///         app_version: env!("CARGO_PKG_VERSION").to_owned(),
+///         platform: std::env::consts::OS.to_owned(),
+///         arch: std::env::consts::ARCH.to_owned(),
+///     });
 ///     // … run app …
 /// }
 /// ```
 pub struct AppContext {
-    /// Application name without a leading dot.
-    ///
-    /// Controls the marker directory: `{root}/.{app_name}/`
+    /// Application name without a leading dot.  Controls the marker
+    /// directory: `{root}/.{app_name}/`.  Shared across all binaries
+    /// (CLI, GUI, etc.) that read/write the same workspace format —
+    /// per-binary identity is tracked separately in
+    /// [`DeviceContext::app_id`].
     pub app_name: &'static str,
     /// When `true`, file-operation methods on [`WorkspaceState`](crate::WorkspaceState)
     /// accept paths outside the workspace root (absolute paths or relative
@@ -52,9 +71,15 @@ pub struct AppContext {
     /// App-specific persistent data directory.  Set once at startup by the
     /// host app via [`set_data_dir`](Self::set_data_dir).
     data_dir: OnceLock<PathBuf>,
-    /// Persistent per-device identifier, lazily loaded (or generated) on
-    /// first call to [`device_id`](Self::device_id).
-    device_id: OnceLock<Uuid>,
+    /// Host-detected device facts supplied by the app at startup via
+    /// [`set_device_defaults`](Self::set_device_defaults).  Required
+    /// before any `device*` getter is called.
+    device_defaults: OnceLock<DeviceDefaults>,
+    /// The per-process device context.  Outer `OnceLock`: lazy init on
+    /// first access, only populated on success (so a failed UUID
+    /// persistence retries on the next call).  Inner `Mutex`: allows
+    /// cross-workspace name propagation to mutate the cached value.
+    device: OnceLock<Mutex<DeviceContext>>,
 }
 
 impl AppContext {
@@ -66,7 +91,8 @@ impl AppContext {
             allow_external_paths: false,
             cache_dir: OnceLock::new(),
             data_dir: OnceLock::new(),
-            device_id: OnceLock::new(),
+            device_defaults: OnceLock::new(),
+            device: OnceLock::new(),
         }
     }
 
@@ -137,27 +163,78 @@ impl AppContext {
             .expect("AppContext::set_data_dir must be called at startup")
     }
 
-    /// Return the persistent device id, generating and storing one on first
-    /// call.  Stored at `<data_dir>/device_id` as plain UTF-8.
+    /// Supply host-detected device facts.  Must be called once at
+    /// startup before any `device*` getter.  Subsequent calls are
+    /// silently ignored (first writer wins).
+    pub fn set_device_defaults(&self, defaults: DeviceDefaults) {
+        let _ = self.device_defaults.set(defaults);
+    }
+
+    /// Snapshot of the per-process device context.
     ///
-    /// Returns an [`Error::Io`](crate::Error::Io) if the data directory
-    /// cannot be created or the file cannot be read / written.  The cached
-    /// id is populated only on success, so a caller may retry after fixing
-    /// the underlying filesystem issue.
+    /// Lazily initialises on first call by loading (or generating) the
+    /// persistent device id and combining it with the defaults supplied
+    /// via [`set_device_defaults`](Self::set_device_defaults).  Returns
+    /// `None` iff the UUID could not be read or written; the error is
+    /// logged at `tracing::error` level.  Subsequent calls after a
+    /// failure will retry, so transient filesystem issues can recover.
     ///
     /// # Panics
-    /// Panics if [`set_data_dir`](Self::set_data_dir) has not been called.
-    pub fn device_id(&self) -> Result<Uuid> {
-        if let Some(id) = self.device_id.get() {
-            return Ok(*id);
+    /// Panics if [`set_data_dir`](Self::set_data_dir) or
+    /// [`set_device_defaults`](Self::set_device_defaults) have not been
+    /// called.
+    pub fn device(&self) -> Option<DeviceContext> {
+        if let Some(mutex) = self.device.get() {
+            return Some(mutex.lock().unwrap().clone());
         }
-        let id = self.load_or_create_device_id()?;
-        // Another thread may have raced us; if so, prefer the stored value
-        // so every caller observes the same id for the process lifetime.
-        Ok(match self.device_id.set(id) {
-            Ok(()) => id,
-            Err(_) => *self.device_id.get().expect("just lost the race"),
-        })
+        let defaults = self
+            .device_defaults
+            .get()
+            .expect("AppContext::set_device_defaults must be called at startup")
+            .clone();
+        let id = match self.load_or_create_device_id() {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::error!("could not persist device_id: {e}");
+                return None;
+            }
+        };
+        let ctx = DeviceContext::from_defaults(id, defaults);
+        // Lost-race-tolerant: whoever sets first wins, everyone observes the same value.
+        let _ = self.device.set(Mutex::new(ctx));
+        Some(self.device.get().unwrap().lock().unwrap().clone())
+    }
+
+    /// Convenience accessor for [`DeviceContext::id`].  Same failure
+    /// semantics as [`device`](Self::device).
+    pub fn device_id(&self) -> Option<Uuid> {
+        self.device().map(|d| d.id)
+    }
+
+    /// Propagate a `(name, updated_at)` pair from a workspace's
+    /// registry back to the per-process context so that any subsequent
+    /// workspace the host app opens observes the rename.
+    ///
+    /// No-op if the context hasn't been initialised yet, or if its
+    /// current `updated_at` is already greater than or equal to the
+    /// supplied timestamp.  Returns `true` when the context actually
+    /// changed.
+    pub fn update_device_name_if_newer(&self, name: &str, updated_at: DateTime<Utc>) -> bool {
+        let Some(mutex) = self.device.get() else {
+            return false;
+        };
+        let mut guard = mutex.lock().unwrap();
+        let is_newer = match guard.updated_at {
+            Some(t) => t < updated_at,
+            None => true,
+        };
+        if is_newer {
+            guard.name = name.to_owned();
+            guard.updated_at = Some(updated_at);
+            true
+        } else {
+            false
+        }
     }
 
     fn load_or_create_device_id(&self) -> Result<Uuid> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,4 +30,4 @@ pub use sapphire_retrieve::{
 // Re-export sapphire-sync public API.
 #[cfg(feature = "git-sync")]
 pub use sapphire_sync::GitSync;
-pub use sapphire_sync::SyncBackend;
+pub use sapphire_sync::{DeviceDefaults, DeviceRecord, DeviceRegistry, SyncBackend};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,4 +30,6 @@ pub use sapphire_retrieve::{
 // Re-export sapphire-sync public API.
 #[cfg(feature = "git-sync")]
 pub use sapphire_sync::GitSync;
-pub use sapphire_sync::{DeviceDefaults, DeviceRecord, DeviceRegistry, SyncBackend};
+pub use sapphire_sync::{
+    DeviceContext, DeviceDefaults, DeviceRecord, DeviceRegistry, MergeOutcome, SyncBackend,
+};

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -161,11 +161,20 @@ impl WorkspaceState {
     ///
     /// When `device_id` is `Some`, the git backend tags every auto-sync commit
     /// with it so each device's syncs are traceable across the shared history.
+    ///
+    /// When both `device_id` and `device_defaults` are provided, the device
+    /// registry at `<marker>/devices.jsonl` is loaded and this device's entry
+    /// is [idempotently registered or reconciled][ensure].  Any actual change
+    /// is saved to disk and staged with the sync backend so the next
+    /// [`sync`](sapphire_sync::SyncBackend::sync) picks it up.
+    ///
+    /// [ensure]: sapphire_sync::DeviceRegistry::ensure_registered
     #[cfg(feature = "git-sync")]
     pub fn open_configured(
         workspace: Workspace,
         sync: &crate::config::SyncConfig,
         device_id: Option<uuid::Uuid>,
+        device_defaults: Option<sapphire_sync::DeviceDefaults>,
     ) -> Result<Self> {
         use crate::config::SyncBackendKind;
         let mut state = Self::open(workspace)?;
@@ -188,7 +197,34 @@ impl WorkspaceState {
                 state.sync_backend = None;
             }
         }
+        if let (Some(id), Some(defaults)) = (device_id, device_defaults) {
+            state.ensure_device_registered(id, defaults)?;
+        }
         Ok(state)
+    }
+
+    /// Ensure the current device is registered in `devices.jsonl`, saving
+    /// and staging the file only if anything changed.  Errors from the
+    /// sync backend's `add_file` are demoted to warnings — the registry
+    /// itself is still consistent on disk.
+    #[cfg(feature = "git-sync")]
+    fn ensure_device_registered(
+        &self,
+        id: uuid::Uuid,
+        defaults: sapphire_sync::DeviceDefaults,
+    ) -> Result<()> {
+        let path = self.workspace.marker_dir().join("devices.jsonl");
+        let mut registry = sapphire_sync::DeviceRegistry::load(&path)?;
+        if !registry.ensure_registered(id, defaults)? {
+            return Ok(());
+        }
+        registry.save()?;
+        if let Some(backend) = self.sync_backend() {
+            if let Err(e) = backend.add_file(&path) {
+                tracing::warn!("could not stage devices.jsonl: {e}");
+            }
+        }
+        Ok(())
     }
 
     /// Tag the git backend's auto-sync commit message with `device_id`.
@@ -212,6 +248,7 @@ impl WorkspaceState {
         workspace: Workspace,
         _sync: &crate::config::SyncConfig,
         _device_id: Option<uuid::Uuid>,
+        _device_defaults: Option<sapphire_sync::DeviceDefaults>,
     ) -> Result<Self> {
         Self::open(workspace)
     }

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -159,24 +159,22 @@ impl WorkspaceState {
     ///   returns an error if no repository is found.
     /// - `SyncBackendKind::None` — disable sync even inside a git repository.
     ///
-    /// When `device_id` is `Some`, the git backend tags every auto-sync commit
-    /// with it so each device's syncs are traceable across the shared history.
-    ///
-    /// When both `device_id` and `device_defaults` are provided, the device
-    /// registry at `<marker>/devices.jsonl` is loaded and this device's entry
-    /// is [idempotently registered or reconciled][ensure].  Any actual change
-    /// is saved to disk and staged with the sync backend so the next
-    /// [`sync`](sapphire_sync::SyncBackend::sync) picks it up.
-    ///
-    /// [ensure]: sapphire_sync::DeviceRegistry::ensure_registered
+    /// The device context is pulled from the workspace's
+    /// [`AppContext`](crate::AppContext) automatically.  When it is
+    /// available, the git backend tags every auto-sync commit with the
+    /// device id and the `<marker>/devices.jsonl` registry is merged
+    /// with the context (see
+    /// [`DeviceRegistry::merge_device_context`](sapphire_sync::DeviceRegistry::merge_device_context)).
+    /// Any resulting change is saved and staged so the next
+    /// [`sync`](sapphire_sync::SyncBackend::sync) picks it up, and the
+    /// merged record's `(name, updated_at)` is propagated back to the
+    /// context via
+    /// [`update_device_name_if_newer`](crate::AppContext::update_device_name_if_newer).
     #[cfg(feature = "git-sync")]
-    pub fn open_configured(
-        workspace: Workspace,
-        sync: &crate::config::SyncConfig,
-        device_id: Option<uuid::Uuid>,
-        device_defaults: Option<sapphire_sync::DeviceDefaults>,
-    ) -> Result<Self> {
+    pub fn open_configured(workspace: Workspace, sync: &crate::config::SyncConfig) -> Result<Self> {
         use crate::config::SyncBackendKind;
+        let device_ctx = workspace.ctx.device();
+        let device_id = device_ctx.as_ref().map(|c| c.id);
         let mut state = Self::open(workspace)?;
         match sync.backend {
             SyncBackendKind::Auto => {
@@ -197,28 +195,65 @@ impl WorkspaceState {
                 state.sync_backend = None;
             }
         }
-        if let (Some(id), Some(defaults)) = (device_id, device_defaults) {
-            state.ensure_device_registered(id, defaults)?;
+        if let Some(ctx) = device_ctx {
+            state.merge_device_registry(&ctx)?;
         }
         Ok(state)
     }
 
-    /// Ensure the current device is registered in `devices.jsonl`, saving
-    /// and staging the file only if anything changed.  Errors from the
-    /// sync backend's `add_file` are demoted to warnings — the registry
-    /// itself is still consistent on disk.
+    /// Merge the per-process device context into this workspace's
+    /// `devices.jsonl`: save+stage the file if anything changed, then
+    /// propagate the merged record's `(name, updated_at)` back to the
+    /// app context so that sibling workspaces opened later observe it.
+    /// Errors from the sync backend's `add_file` are demoted to
+    /// warnings — the registry itself is still consistent on disk.
     #[cfg(feature = "git-sync")]
-    fn ensure_device_registered(
-        &self,
-        id: uuid::Uuid,
-        defaults: sapphire_sync::DeviceDefaults,
-    ) -> Result<()> {
+    fn merge_device_registry(&self, ctx: &sapphire_sync::DeviceContext) -> Result<()> {
         let path = self.workspace.marker_dir().join("devices.jsonl");
         let mut registry = sapphire_sync::DeviceRegistry::load(&path)?;
-        if !registry.ensure_registered(id, defaults)? {
-            return Ok(());
+        let outcome = registry.merge_device_context(ctx);
+        if outcome.changed {
+            registry.save()?;
+            if let Some(backend) = self.sync_backend() {
+                if let Err(e) = backend.add_file(&path) {
+                    tracing::warn!("could not stage devices.jsonl: {e}");
+                }
+            }
         }
+        self.workspace
+            .ctx
+            .update_device_name_if_newer(&outcome.record.name, outcome.record.updated_at);
+        Ok(())
+    }
+
+    /// Rename this device in the workspace's registry, bump
+    /// `updated_at`, save + stage the file via the sync backend, and
+    /// propagate the new `(name, updated_at)` back to the app context.
+    ///
+    /// Fails if the device context hasn't been initialised (e.g. the
+    /// UUID could not be persisted) or if the current device isn't
+    /// already in the registry — the usual caller
+    /// ([`open_configured`](Self::open_configured)) ensures both.
+    #[cfg(feature = "git-sync")]
+    pub fn rename_device(&self, name: &str) -> Result<()> {
+        let id = self
+            .workspace
+            .ctx
+            .device()
+            .ok_or_else(|| {
+                Error::Sync(sapphire_sync::Error::DeviceNotFound {
+                    id: uuid::Uuid::nil(),
+                })
+            })?
+            .id;
+        let path = self.workspace.marker_dir().join("devices.jsonl");
+        let mut registry = sapphire_sync::DeviceRegistry::load(&path)?;
+        registry.set_name(id, name)?;
         registry.save()?;
+        let record = registry.lookup(id).expect("just wrote this record").clone();
+        self.workspace
+            .ctx
+            .update_device_name_if_newer(&record.name, record.updated_at);
         if let Some(backend) = self.sync_backend() {
             if let Err(e) = backend.add_file(&path) {
                 tracing::warn!("could not stage devices.jsonl: {e}");
@@ -247,8 +282,6 @@ impl WorkspaceState {
     pub fn open_configured(
         workspace: Workspace,
         _sync: &crate::config::SyncConfig,
-        _device_id: Option<uuid::Uuid>,
-        _device_defaults: Option<sapphire_sync::DeviceDefaults>,
     ) -> Result<Self> {
         Self::open(workspace)
     }


### PR DESCRIPTION
## Summary
- `sapphire-sync` に `DeviceRegistry` を新設。`.sapphire-workspace/devices.jsonl` にデバイス一覧（UUIDv7 / name / hostname / client+version / platform / arch / registered_at / updated_at）を JSONL で永続化し、git 経由で全デバイスに配布する。
- ワークスペース読み込み時（`WorkspaceState::open_configured`）に自デバイスが未登録なら自動追記。既存エントリの `client` / `client_version` がバイナリと食い違う場合のみ自動同期し `updated_at` を bump。他のホスト情報フィールドは初回固定。
- 新サブコマンド `sapphire-workspace device {list, set-name, show}` を追加。UI から利用できる逆引きベースとして、UUID からデバイス名への解決と UUIDv7 順の 1-based Device Number を提供。`set-name` は `updated_at` を更新し git backend に stage する（次回 `sync` で push）。
- `updated_at` は将来的に複数ワークスペースを同時に開く GUI が自デバイス情報を伝播する際の判定に使う想定（ライブラリ側には `DeviceRegistry::update_if_newer` を用意）。

## Test plan
- [x] `cargo test --workspace` 全緑（`DeviceRegistry` 10 新規テスト含む: 初回登録 / idempotent / client_version 自動同期 / UUIDv7 ソート / ラウンドトリップ / set_name / update_if_newer / 壊れた行のエラー処理）
- [x] CLI スモーク: `init` → `device list`（自動登録）→ `device show`（全フィールド表示）→ `device set-name` → `devices.jsonl` の `name` 更新と `updated_at` bump を確認、`git status` で stage 済みを確認
- [x] `client_version` を手動で古い値に書き換え後 `device list` で自動的に現バイナリ版へ戻り、`registered_at` は不変・`updated_at` のみ更新されることを確認
- [ ] 実リモートを設定した 2 台での同期シナリオ（別マシン B で pull → registry に A のエントリが見える / B 側の登録も push される）は未検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)