### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to `sapphire-workspace` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-04-20
+
+### Changed (breaking)
+
+- `sapphire-sync`: `SyncConfig` collapsed back into a single flat struct (`backend`, `remote`, `branch`); `WorkspaceSyncConfig` and `UserSyncConfig` are gone. The workspace/user split no longer carries meaningful distinction once `device_id` moves out of config. (#45)
+- `sapphire-sync`: `sync_interval_minutes` dropped from `SyncConfig`; periodic cadence is the host app's concern (the CLI exposes it as `UserConfig::sync_interval_minutes`).
+- `sapphire-retrieve`: `RetrieveConfig::sync_interval_minutes` and `sync_interval()` removed.
+- `sapphire-workspace`: `WorkspaceState::sync_git` / `sync_retrieve` / `periodic_sync` helpers removed. `watch` in the CLI collapses its two independent timers into a single `periodic_sync()` tick backed by `sync()`.
+- `sapphire-workspace`: `WorkspaceState::open_configured` no longer takes a device id / defaults pair — it reads them from the workspace's `AppContext`.
+- `sapphire-workspace`: `device_id` is no longer stored in `config.toml`. `AppContext::device_id()` is now a get-or-create accessor backed by `<data_dir>/device_id`; first call generates a UUIDv7 and persists it.
+- `sapphire-workspace`: `AppContext` gains `data_dir` / `set_data_dir`, and the library's `dirs` dependency is dropped. Host apps are expected to resolve and inject both `cache_dir` and `data_dir` at startup so the library stays portable to mobile sandboxes.
+- `sapphire-sync`: git auto-sync commits now use an RFC 822 / `git interpret-trailers` compatible `Device-Id:` trailer (message becomes `auto: sync by [<uuid>]\n\nDevice-Id: <uuid>`). `GitSync` exposes only `with_device_id(Uuid)`; commit formatting is fully encapsulated.
+
+### Added
+
+- `sapphire-sync`: `DeviceRegistry` backed by a JSONL file (`{marker}/devices.jsonl`) recording each device's hostname, app id/version, platform, arch, and `registered_at` / `updated_at` timestamps. Enables reverse lookup from commit UUIDs and a stable 1-based Device Number derived from UUIDv7 order. (#46)
+- `sapphire-workspace`: `DeviceContext` (process-wide device state) on `AppContext` via `set_device_defaults`, `device()`, and `update_device_name_if_newer`. Host-detected fields (hostname, app_id, app_version, platform, arch) are always refreshed from the running binary on open; only user-editable fields (`name`, `updated_at`) follow the "newer `updated_at` wins" rule, so an app-version bump no longer touches `updated_at`.
+- `sapphire-workspace-cli`: `device {list, set-name, show}` subcommands exposing the registry; renames are staged via the git backend so the next `sync` propagates them.
+- `sapphire-workspace-cli`: top-level `tracing_subscriber` initialised once in `main()`; device-id persistence failures now surface via `tracing::error!` instead of ad-hoc `eprintln!`.
+
+### Renamed
+
+- `sapphire-sync`: `client` / `client_version` renamed to `app_id` / `app_version` across the device registry — this is a local-first app, not client-server, and the new names match `env!("CARGO_PKG_NAME")` / `env!("CARGO_PKG_VERSION")`.
+
 ## [0.9.0] - 2026-04-18
 
 ### Changed (breaking)
@@ -162,6 +186,7 @@ Internal repository restructure; no public API changes.
 - `fastembed-embed`, `lancedb-store`, `sqlite-store`, `git-sync` feature flags.
 - Re-exports of `sapphire-retrieve` and `sapphire-sync` public APIs.
 
+[0.10.0]: https://github.com/fluo10/sapphire-workspace/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.8.1...workspace-v0.9.0
 [0.8.1]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.8.0...workspace-v0.8.1
 [0.8.0]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.7.1...workspace-v0.8.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 description = "Workspace management library for indexing, search, and sync of file-based documents"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-workspace"
@@ -52,8 +52,8 @@ fastembed-embed = ["sapphire-retrieve/fastembed-embed"]
 git-sync        = ["sapphire-sync/git"]
 
 [dependencies]
-sapphire-retrieve = { version = "0.9.0", path = "crates/sapphire-retrieve", default-features = false }
-sapphire-sync     = { version = "0.9.0", path = "crates/sapphire-sync", default-features = false }
+sapphire-retrieve = { version = "0.10.0", path = "crates/sapphire-retrieve", default-features = false }
+sapphire-sync     = { version = "0.10.0", path = "crates/sapphire-sync", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Workspace management library for indexing, search, and sync of Markdown document
 
 ```toml
 [dependencies]
-sapphire-workspace = "0.7"
+sapphire-workspace = "0.10"
 ```
 
 ### Initialise a workspace

--- a/crates/sapphire-retrieve/src/db.rs
+++ b/crates/sapphire-retrieve/src/db.rs
@@ -100,10 +100,10 @@ impl RetrieveStore for InMemoryStore {
             .documents
             .values()
             .filter(|doc| {
-                if let Some(ref pfx) = prefix {
-                    if !doc.path.starts_with(pfx.as_str()) {
-                        return false;
-                    }
+                if let Some(ref pfx) = prefix
+                    && !doc.path.starts_with(pfx.as_str())
+                {
+                    return false;
                 }
                 doc.body.to_lowercase().contains(&needle)
             })

--- a/crates/sapphire-retrieve/src/sqlite_store.rs
+++ b/crates/sapphire-retrieve/src/sqlite_store.rs
@@ -343,7 +343,7 @@ impl RetrieveStore for SqliteStore {
             .filter(|r| {
                 prefix
                     .as_ref()
-                    .map_or(true, |pfx| r.path.starts_with(pfx.as_str()))
+                    .is_none_or(|pfx| r.path.starts_with(pfx.as_str()))
             })
             .collect();
 

--- a/crates/sapphire-sync/src/git_sync.rs
+++ b/crates/sapphire-sync/src/git_sync.rs
@@ -157,12 +157,12 @@ impl GitSync {
             let username = username_from_url.unwrap_or("git");
 
             // Attempt 0: ssh-agent.
-            if i == 0 {
-                if let Ok(cred) = Cred::ssh_key_from_agent(username) {
-                    return Ok(cred);
-                }
-                // ssh-agent unavailable — fall through to key files immediately.
+            if i == 0
+                && let Ok(cred) = Cred::ssh_key_from_agent(username)
+            {
+                return Ok(cred);
             }
+            // ssh-agent unavailable — fall through to key files immediately.
 
             // Attempts 1..=KEY_NAMES.len(): key files.
             let key_idx = if i == 0 { 0 } else { i - 1 };

--- a/crates/sapphire-workspace-cli/Cargo.toml
+++ b/crates/sapphire-workspace-cli/Cargo.toml
@@ -19,7 +19,7 @@ fastembed-embed = ["sapphire-workspace/fastembed-embed"]
 git-sync        = ["sapphire-workspace/git-sync"]
 
 [dependencies]
-sapphire-workspace = { version = "0.9.0", path = "../..", default-features = false }
+sapphire-workspace = { version = "0.10.0", path = "../..", default-features = false }
 clap.workspace = true
 anyhow.workspace = true
 serde.workspace = true

--- a/crates/sapphire-workspace-cli/src/commands/device.rs
+++ b/crates/sapphire-workspace-cli/src/commands/device.rs
@@ -41,8 +41,8 @@ fn run_list(workspace_dir: Option<&Path>) -> Result<()> {
         return Ok(());
     }
     println!(
-        " {:>2}  {:36}  {:20}  {:24}  {:8}  {}",
-        "#", "id", "name", "app", "platform", "updated_at"
+        " {:>2}  {:36}  {:20}  {:24}  {:8}  updated_at",
+        "#", "id", "name", "app", "platform"
     );
     for (i, r) in registry.records().iter().enumerate() {
         let marker = if Some(r.id) == self_id { "*" } else { " " };

--- a/crates/sapphire-workspace-cli/src/commands/watch.rs
+++ b/crates/sapphire-workspace-cli/src/commands/watch.rs
@@ -49,17 +49,17 @@ pub fn run(workspace_dir: Option<&Path>, debounce_ms: u64) -> Result<()> {
         // Run the periodic sync cycle (git sync + retrieve cache refresh) when
         // its interval has elapsed.
         let run_periodic_sync = |last: &mut Instant| {
-            if let Some(interval) = sync_interval {
-                if last.elapsed() >= interval {
-                    print!("periodic sync... ");
-                    match state_clone.periodic_sync() {
-                        Ok((upserted, removed)) => {
-                            println!("done (upserted: {upserted}, removed: {removed})")
-                        }
-                        Err(e) => eprintln!("periodic sync error: {e}"),
+            if let Some(interval) = sync_interval
+                && last.elapsed() >= interval
+            {
+                print!("periodic sync... ");
+                match state_clone.periodic_sync() {
+                    Ok((upserted, removed)) => {
+                        println!("done (upserted: {upserted}, removed: {removed})")
                     }
-                    *last = Instant::now();
+                    Err(e) => eprintln!("periodic sync error: {e}"),
                 }
+                *last = Instant::now();
             }
         };
 

--- a/crates/sapphire-workspace-cli/src/mcp.rs
+++ b/crates/sapphire-workspace-cli/src/mcp.rs
@@ -90,18 +90,16 @@ impl RecallServer {
         description = "Show workspace location, index path, schema version, and document count."
     )]
     fn workspace_info(&self, _: Parameters<serde_json::Value>) -> Result<String, String> {
-        (|| -> anyhow::Result<String> {
-            self.with_state(|s| {
-                let info = s.db_info()?;
-                Ok(format!(
-                    "workspace:      {}\ndb path:        {}\nschema version: v{}\ndocuments:      {}",
-                    s.workspace.root.display(),
-                    info.db_path.display(),
-                    info.schema_version,
-                    info.document_count,
-                ))
-            })
-        })()
+        self.with_state(|s| {
+            let info = s.db_info()?;
+            Ok(format!(
+                "workspace:      {}\ndb path:        {}\nschema version: v{}\ndocuments:      {}",
+                s.workspace.root.display(),
+                info.db_path.display(),
+                info.schema_version,
+                info.document_count,
+            ))
+        })
         .map_err(|e| e.to_string())
     }
 
@@ -109,12 +107,10 @@ impl RecallServer {
         Walks the workspace directory, upserts new/changed documents, and removes \
         documents for deleted files. Returns the number of files synced.")]
     fn workspace_sync(&self, _: Parameters<serde_json::Value>) -> Result<String, String> {
-        (|| -> anyhow::Result<String> {
-            self.with_state(|s| {
-                let (upserted, _removed) = s.sync()?;
-                Ok(format!("synced: {upserted} files"))
-            })
-        })()
+        self.with_state(|s| {
+            let (upserted, _removed) = s.sync()?;
+            Ok(format!("synced: {upserted} files"))
+        })
         .map_err(|e| e.to_string())
     }
 
@@ -146,35 +142,33 @@ impl RecallServer {
         line ranges (`line_start`, `line_end`) and text within each file."
     )]
     fn search(&self, Parameters(p): Parameters<SearchParams>) -> Result<String, String> {
-        (|| -> anyhow::Result<String> {
-            self.with_state(|s| {
-                s.sync()?;
-                let limit = p.limit.unwrap_or(10);
+        self.with_state(|s| {
+            s.sync()?;
+            let limit = p.limit.unwrap_or(10);
 
-                // Opportunistically embed a small backlog before searching.
-                if let Some(embedder) = s.embedder() {
-                    let pending = s
-                        .retrieve_db()
-                        .vec_info()
-                        .map(|vi| vi.pending_count)
-                        .unwrap_or(0);
-                    if pending > 0 && pending <= 50 {
-                        let _ = s.retrieve_db().embed_pending(embedder, &|_, _| {});
-                    }
-                }
-
-                let mut hq = HybridQuery::new(p.query.as_str()).limit(limit);
-                if let Some(e) = s.embedder() {
-                    hq = hq.embedder(e);
-                }
-
-                let results = s
+            // Opportunistically embed a small backlog before searching.
+            if let Some(embedder) = s.embedder() {
+                let pending = s
                     .retrieve_db()
-                    .search_hybrid(&hq)
-                    .map_err(anyhow::Error::msg)?;
-                Ok(serde_json::to_string_pretty(&results)?)
-            })
-        })()
+                    .vec_info()
+                    .map(|vi| vi.pending_count)
+                    .unwrap_or(0);
+                if pending > 0 && pending <= 50 {
+                    let _ = s.retrieve_db().embed_pending(embedder, &|_, _| {});
+                }
+            }
+
+            let mut hq = HybridQuery::new(p.query.as_str()).limit(limit);
+            if let Some(e) = s.embedder() {
+                hq = hq.embedder(e);
+            }
+
+            let results = s
+                .retrieve_db()
+                .search_hybrid(&hq)
+                .map_err(anyhow::Error::msg)?;
+            Ok(serde_json::to_string_pretty(&results)?)
+        })
         .map_err(|e| e.to_string())
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -239,12 +239,12 @@ impl AppContext {
 
     fn load_or_create_device_id(&self) -> Result<Uuid> {
         let path = self.data_dir().join("device_id");
-        if let Ok(contents) = std::fs::read_to_string(&path) {
-            if let Ok(id) = contents.trim().parse::<Uuid>() {
-                return Ok(id);
-            }
-            // Existing file is corrupt — fall through and regenerate.
+        if let Ok(contents) = std::fs::read_to_string(&path)
+            && let Ok(id) = contents.trim().parse::<Uuid>()
+        {
+            return Ok(id);
         }
+        // Existing file is corrupt — fall through and regenerate.
         let id = Uuid::now_v7();
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -214,10 +214,10 @@ impl WorkspaceState {
         let outcome = registry.merge_device_context(ctx);
         if outcome.changed {
             registry.save()?;
-            if let Some(backend) = self.sync_backend() {
-                if let Err(e) = backend.add_file(&path) {
-                    tracing::warn!("could not stage devices.jsonl: {e}");
-                }
+            if let Some(backend) = self.sync_backend()
+                && let Err(e) = backend.add_file(&path)
+            {
+                tracing::warn!("could not stage devices.jsonl: {e}");
             }
         }
         self.workspace
@@ -254,10 +254,10 @@ impl WorkspaceState {
         self.workspace
             .ctx
             .update_device_name_if_newer(&record.name, record.updated_at);
-        if let Some(backend) = self.sync_backend() {
-            if let Err(e) = backend.add_file(&path) {
-                tracing::warn!("could not stage devices.jsonl: {e}");
-            }
+        if let Some(backend) = self.sync_backend()
+            && let Err(e) = backend.add_file(&path)
+        {
+            tracing::warn!("could not stage devices.jsonl: {e}");
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Bump workspace to `0.10.0` and update CHANGELOG.
- Library API: flat `SyncConfig`, `AppContext` owns device/data dirs, `device_id` persisted to `<data_dir>/device_id` (#45).
- New device registry synced via `devices.jsonl`, plus CLI `device {list,set-name,show}` subcommands (#46).
- `dirs` dependency dropped from the library — host apps inject cache/data paths.

Tagging & publish are handled by `.github/workflows/release.yml` on merge (branch is `release/0.10.0` → tag `v0.10.0`, crates published in dependency order, GitHub release with CLI binaries for linux x86_64/aarch64, macOS arm64, windows x86_64).

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test --workspace --no-run`
- [ ] CI green on this PR
- [ ] After merge: confirm `release`, `cargo-publish`, and `build` jobs succeed and `v0.10.0` tag + GitHub release appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)