### PR TITLE
release: v0.10.1 (hotfix for #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `sapphire-workspace` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-04-22
+
+### Fixed
+
+- `sapphire-workspace`: `WorkspaceState::write_file` could not create new files — `canonicalize_or_parent` returned paths with a trailing separator (e.g. `/workspace/memory/daily/2026-04-19.md/`) for not-yet-existing files, and `std::fs::write` failed with `EISDIR`. `Path::join` with an empty path appends a separator; the walk-up loop now seeds its suffix with `PathBuf::from(name)` on the first iteration. Existing files were unaffected because the `canonicalize()` fast-path skipped the buggy branch. (#48)
+
 ## [0.10.0] - 2026-04-20
 
 ### Changed (breaking)
@@ -186,6 +192,7 @@ Internal repository restructure; no public API changes.
 - `fastembed-embed`, `lancedb-store`, `sqlite-store`, `git-sync` feature flags.
 - Re-exports of `sapphire-retrieve` and `sapphire-sync` public APIs.
 
+[0.10.1]: https://github.com/fluo10/sapphire-workspace/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/fluo10/sapphire-workspace/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.8.1...workspace-v0.9.0
 [0.8.1]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.8.0...workspace-v0.8.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.10.1"
 description = "Workspace management library for indexing, search, and sync of file-based documents"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-workspace"
@@ -52,8 +52,8 @@ fastembed-embed = ["sapphire-retrieve/fastembed-embed"]
 git-sync        = ["sapphire-sync/git"]
 
 [dependencies]
-sapphire-retrieve = { version = "0.10.0", path = "crates/sapphire-retrieve", default-features = false }
-sapphire-sync     = { version = "0.10.0", path = "crates/sapphire-sync", default-features = false }
+sapphire-retrieve = { version = "0.10.1", path = "crates/sapphire-retrieve", default-features = false }
+sapphire-sync     = { version = "0.10.1", path = "crates/sapphire-sync", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/sapphire-workspace-cli/Cargo.toml
+++ b/crates/sapphire-workspace-cli/Cargo.toml
@@ -19,7 +19,7 @@ fastembed-embed = ["sapphire-workspace/fastembed-embed"]
 git-sync        = ["sapphire-workspace/git-sync"]
 
 [dependencies]
-sapphire-workspace = { version = "0.10.0", path = "../..", default-features = false }
+sapphire-workspace = { version = "0.10.1", path = "../..", default-features = false }
 clap.workspace = true
 anyhow.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Hotfix release for [#48](https://github.com/fluo10/sapphire-workspace/issues/48): `WorkspaceState::write_file` could not create new files — `canonicalize_or_parent` returned paths with a trailing separator for not-yet-existing files and `std::fs::write` failed with `EISDIR`. Impacted daily-log generation and new memory entries in sapphire-agent consistently. Fixed by #49 (already merged to main).

## Contents

- Version bump `0.10.0` → `0.10.1` across `Cargo.toml` (workspace) and `crates/sapphire-workspace-cli/Cargo.toml`.
- `CHANGELOG.md`: `[0.10.1] - 2026-04-22` section under `### Fixed` + compare link.

Merging this PR triggers the `release.yml` workflow: multi-target binary builds, `cargo publish` for `sapphire-retrieve` → `sapphire-sync` → `sapphire-workspace`, `v0.10.1` tag, and a GitHub release with binaries attached.

## Test plan

- [x] `cargo test --lib --package sapphire-workspace` (regression tests from #49 pass)
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace` (all crates build at 0.10.1)
- [ ] CI `release.yml` succeeds on merge (builds, cargo publish, tag + GitHub release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)