### PR TITLE
chore(deps): bump lancedb to 0.29 (with arrow 58) and md-5 to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,4 +63,4 @@ indexmap.workspace = true
 walkdir = "2"
 uuid.workspace = true
 chrono = { workspace = true }
-md-5 = "0.10"
+md-5 = "0.11"

--- a/crates/sapphire-retrieve/Cargo.toml
+++ b/crates/sapphire-retrieve/Cargo.toml
@@ -25,8 +25,8 @@ serde.workspace = true
 serde_json.workspace = true
 ureq = { version = "3.3", features = ["json"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-lancedb = { version = "0.27", optional = true }
-arrow-array = { version = "57", optional = true }
-arrow-schema = { version = "57", optional = true }
+lancedb = { version = "0.29", optional = true }
+arrow-array = { version = "58", optional = true }
+arrow-schema = { version = "58", optional = true }
 futures = { version = "0.3", optional = true }
 fastembed = { version = "5.13", optional = true }


### PR DESCRIPTION
## Summary
- Bumps `lancedb` from 0.27 to 0.29 and `arrow-array`/`arrow-schema` from 57 to 58 in `sapphire-retrieve` (lancedb 0.29 requires arrow 58, so they must move together)
- Bumps `md-5` from 0.10 to 0.11 in the workspace

Supersedes #54, which only bumped `lancedb` and failed to build because `arrow` was left at 57. Also applies the `md-5` bump that #51 and #52 attempted but left as empty commits.

Local verification (rustc 1.95.0, matching CI):
- `cargo build --workspace --all-features` ✅
- `cargo test -p sapphire-retrieve --features lancedb-store` ✅ (15 unit + 1 doctest)
- `cargo clippy -p sapphire-retrieve --all-features --all-targets -- -D warnings` ✅

## Test plan
- [ ] CI passes
- [ ] Close #54 once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)