### PR TITLE
release: v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to `sapphire-workspace` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-05-16
+
+### Changed (breaking)
+
+- `sapphire-retrieve`: `JsonChunker` is renamed to `JsonlChunker` and reduced to per-line JSON parsing with a raw-text fallback for partial writes. The previous array / nested-messages support was unused outside the JSONL path. (#53)
+- `sapphire-workspace`: plain `.json` files are no longer indexed. The bulk indexer and `on_file_updated` now skip them; only `.jsonl` is processed through the JSONL chunker. (#53)
+- `sapphire-workspace`: existing retrieve indexes built on a previous version will have stale chunk boundaries for `.jsonl` files. A re-index is recommended after upgrading so that subsequent appends are picked up incrementally rather than re-embedding the file.
+
+### Performance
+
+- `sapphire-workspace`: `on_file_updated` pre-chunks `.jsonl` files line-by-line instead of falling back to the storage-layer paragraph chunker. Previously every append shifted chunk boundaries and re-embedded most of the file; now existing lines retain their `(doc_id, line_start)` identity and only the appended lines are embedded. (#53)
+
+### Changed
+
+- `sapphire-retrieve`: bump `lancedb` from 0.27 to 0.29 and `arrow-array` / `arrow-schema` from 57 to 58 in lockstep. (#55)
+- `sapphire-workspace`: bump `md-5` from 0.10 to 0.11. (#52)
+
 ## [0.10.1] - 2026-04-22
 
 ### Fixed
@@ -192,6 +209,7 @@ Internal repository restructure; no public API changes.
 - `fastembed-embed`, `lancedb-store`, `sqlite-store`, `git-sync` feature flags.
 - Re-exports of `sapphire-retrieve` and `sapphire-sync` public APIs.
 
+[0.11.0]: https://github.com/fluo10/sapphire-workspace/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/fluo10/sapphire-workspace/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/fluo10/sapphire-workspace/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/fluo10/sapphire-workspace/compare/workspace-v0.8.1...workspace-v0.9.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.10.1"
+version = "0.11.0"
 description = "Workspace management library for indexing, search, and sync of file-based documents"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-workspace"
@@ -52,8 +52,8 @@ fastembed-embed = ["sapphire-retrieve/fastembed-embed"]
 git-sync        = ["sapphire-sync/git"]
 
 [dependencies]
-sapphire-retrieve = { version = "0.10.1", path = "crates/sapphire-retrieve", default-features = false }
-sapphire-sync     = { version = "0.10.1", path = "crates/sapphire-sync", default-features = false }
+sapphire-retrieve = { version = "0.11.0", path = "crates/sapphire-retrieve", default-features = false }
+sapphire-sync     = { version = "0.11.0", path = "crates/sapphire-sync", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/sapphire-workspace-cli/Cargo.toml
+++ b/crates/sapphire-workspace-cli/Cargo.toml
@@ -19,7 +19,7 @@ fastembed-embed = ["sapphire-workspace/fastembed-embed"]
 git-sync        = ["sapphire-workspace/git-sync"]
 
 [dependencies]
-sapphire-workspace = { version = "0.10.1", path = "../..", default-features = false }
+sapphire-workspace = { version = "0.11.0", path = "../..", default-features = false }
 clap.workspace = true
 anyhow.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Minor release covering a breaking change to the JSONL chunking path plus dependency bumps.

## Highlights

- **Breaking** (#53): `sapphire-retrieve::JsonChunker` → `JsonlChunker`; plain `.json` files are no longer indexed; existing retrieve indexes have stale JSONL chunk boundaries and should be re-built so subsequent appends are picked up incrementally.
- **Performance** (#53): `on_file_updated` pre-chunks `.jsonl` line-by-line instead of falling back to the paragraph chunker, so appended lines no longer cause the whole file to be re-embedded.
- **Dependencies**: `lancedb` 0.27 → 0.29 + `arrow-array` / `arrow-schema` 57 → 58 in lockstep (#55); `md-5` 0.10 → 0.11 (#52).

## Contents

- Version bump `0.10.1` → `0.11.0` across `Cargo.toml` (workspace) and `crates/sapphire-workspace-cli/Cargo.toml`.
- `CHANGELOG.md`: `[0.11.0] - 2026-05-16` section with `### Changed (breaking)`, `### Performance`, `### Changed` + compare link.

Merging this PR triggers the `release.yml` workflow: multi-target binary builds, `cargo publish` for `sapphire-retrieve` → `sapphire-sync` → `sapphire-workspace`, `v0.11.0` tag, and a GitHub release with binaries attached.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-features` (clean, only pre-existing dead-code warning)
- [ ] CI `release.yml` succeeds on merge (builds, cargo publish, tag + GitHub release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)