### PR TITLE
chore(release): introduce release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,59 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+# release コマンドと release-pr が同じブランチで競合しないように
+# 1 つの release-plz workflow が走っている間は次回起動を待たせる。
+concurrency:
+  group: release-plz-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake
+
+      - uses: MarcoIeni/release-plz-action@v0
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake
+
+      - uses: MarcoIeni/release-plz-action@v0
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,13 @@
-name: Release
+name: Release binaries
 
+# release-plz が GitHub release を作成した時にバイナリビルドを起動する。
+# crates.io publish と tag/release 作成は release-plz.yml が担当。
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
+  release:
+    types: [published]
 
 jobs:
   build:
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     strategy:
       fail-fast: false
       matrix:
@@ -25,10 +25,12 @@ jobs:
             target: x86_64-pc-windows-msvc
             ext: ".exe"
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.release.tag_name }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -58,90 +60,8 @@ jobs:
           cp target/${{ matrix.target }}/release/sapphire-workspace${{ matrix.ext }} \
              dist/sapphire-workspace-${{ matrix.target }}${{ matrix.ext }}
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: sapphire-workspace-${{ matrix.target }}
-          path: dist/
-
-  cargo-publish:
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
-
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake
-
-      - name: Publish sapphire-retrieve
-        run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "sapphire-retrieve") | .version')
-          if curl -sf "https://crates.io/api/v1/crates/sapphire-retrieve/$VERSION" > /dev/null; then
-            echo "sapphire-retrieve $VERSION already published, skipping"
-          else
-            cargo publish -p sapphire-retrieve
-          fi
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-      - name: Publish sapphire-sync
-        run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "sapphire-sync") | .version')
-          if curl -sf "https://crates.io/api/v1/crates/sapphire-sync/$VERSION" > /dev/null; then
-            echo "sapphire-sync $VERSION already published, skipping"
-          else
-            cargo publish -p sapphire-sync
-          fi
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-      - name: Publish sapphire-workspace
-        run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "sapphire-workspace") | .version')
-          if curl -sf "https://crates.io/api/v1/crates/sapphire-workspace/$VERSION" > /dev/null; then
-            echo "sapphire-workspace $VERSION already published, skipping"
-          else
-            cargo publish -p sapphire-workspace
-          fi
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
-  release:
-    needs: [build, cargo-publish]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
-
-      - name: Extract version from branch name
-        id: version
-        run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
-          VERSION="${BRANCH#release/}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v8
-        with:
-          path: artifacts/
-          merge-multiple: true
-
-      - name: Create tag and GitHub release
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag v${{ steps.version.outputs.version }}
-          git push origin v${{ steps.version.outputs.version }}
-          gh release create v${{ steps.version.outputs.version }} \
-            --title "v${{ steps.version.outputs.version }}" \
-            --generate-notes \
-            artifacts/*
+      - name: Upload binary to release
         env:
           GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,46 @@
+[workspace]
+# 公開クレートはすべて統一バージョン（workspace.package.version）で運用する。
+# 既存タグ運用に合わせて、ワークスペース全体で 1 つの `v{version}` タグと
+# GitHub release だけを作る。crates.io publish は各クレート個別に行う。
+changelog_update = true
+dependencies_update = true
+publish = true
+release = true
+git_release_enable = false
+git_tag_enable = false
+pr_branch_prefix = "release-plz/"
+pr_labels = ["release"]
+
+# メイン crate がタグと GitHub release を担当する。
+[[package]]
+name = "sapphire-workspace"
+git_tag_enable = true
+git_release_enable = true
+git_tag_name = "v{{ version }}"
+git_release_name = "v{{ version }}"
+version_group = "workspace"
+
+[[package]]
+name = "sapphire-retrieve"
+version_group = "workspace"
+
+[[package]]
+name = "sapphire-sync"
+version_group = "workspace"
+
+# CLI は publish = false かつ独自バージョンなので release-plz の対象外。
+[[package]]
+name = "sapphire-workspace-cli"
+release = false
+
+[changelog]
+# 既存 CHANGELOG.md のヘッダーをそのまま維持し、新規エントリは
+# このヘッダーの下に挿入される（既存履歴は保持される）。
+header = """# Changelog
+
+All notable changes to `sapphire-workspace` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+"""


### PR DESCRIPTION
## Summary
- `release-plz.toml` を新規追加。3 つの公開クレートを `version_group = \"workspace\"` で統一バージョン管理し、`sapphire-workspace` が `v{version}` 単一タグと GitHub release を担当。`sapphire-workspace-cli` は `publish = false` で対象外。CHANGELOG 既存ヘッダーは保持され、既存履歴も残ります。
- `.github/workflows/release-plz.yml` を新規追加。`push: main` で release PR の作成と、merge 後の crates.io publish / tag / GH release 作成を行う。
- 既存 `.github/workflows/release.yml` を `release: published` トリガーに改修。バイナリビルド＋ `gh release upload` のみに縮小し、`cargo publish` と tag 作成は release-plz に移譲。

## 動作の流れ（マージ後）
1. main への push を契機に release-plz が動き、pending な変更（例: 直近の `git2 0.20 → 0.21`）から release PR を自動作成。
2. PR の中身（CHANGELOG / `Cargo.toml` のバージョン）を確認してマージ。
3. release-plz が `v{version}` タグと GH release を作り、3 クレートを crates.io に publish。
4. GH release が published になると `release.yml` が起動し、各プラットフォーム向け CLI バイナリを release にアップロード。

## 前提
- リポジトリ secret に `RELEASE_PLZ_TOKEN` （fine-grained PAT、Contents + Pull requests の read/write）が登録されていること
- `CARGO_REGISTRY_TOKEN` は既存のものを継続利用

## メモ
- conventional commits の `feat!` / `chore!` / フッターの `BREAKING CHANGE:` で minor bump を強制可能（pre-1.0）。
- 今回 git2 を minor として上げたい場合は、release PR のバージョンを手動で 0.12.0 に書き換えてマージするのが分かりやすい運用テストになります。

## Test plan
- [ ] PR マージ後、release-plz workflow が成功し release PR が出ること
- [ ] release PR の差分（CHANGELOG, Cargo.toml, Cargo.lock）が想定通りであること
- [ ] release PR マージ後に `v{version}` タグ・GH release・crates.io publish が完了すること
- [ ] release.yml が GH release の published を受けてバイナリをアップロードすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)