### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ Cargo.lock
 tmp
 .sapphire-workspace
 .cargo
+
+# macOS Finder metadata
+.DS_Store
+**/.DS_Store


### PR DESCRIPTION
## Summary
- macOS の Finder が生成する `.DS_Store` を `.gitignore` に追加。

## Test plan
- [ ] 既存のトラッキング対象に `.DS_Store` がないことを確認（`git ls-files | grep DS_Store` が空）

🤖 Generated with [Claude Code](https://claude.com/claude-code)