### PR TITLE
fix(ci): update release-plz action to release-plz/action@v0.5

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake
 
-      - uses: MarcoIeni/release-plz-action@v0
+      - uses: release-plz/action@v0.5
         with:
           command: release
         env:
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler cmake
 
-      - uses: MarcoIeni/release-plz-action@v0
+      - uses: release-plz/action@v0.5
         with:
           command: release-pr
         env:


### PR DESCRIPTION
## Summary
- #58 で導入した `MarcoIeni/release-plz-action@v0` が解決できず Actions が失敗していた。
- リポジトリが `MarcoIeni/release-plz-action` → `release-plz/action` にリネームされており、また rolling な `v0` タグは存在せず、現行の major rolling タグは `v0.5` (latest: `v0.5.129`)。
- workflow の2箇所の `uses:` をまとめて差し替え。

## Test plan
- [ ] main マージ後、Release-plz workflow が action 解決エラーなしに起動すること
- [ ] release PR が作成されるか、または release ジョブが正常終了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)