### PR TITLE
fix(ci): set publish = false for sapphire-workspace-cli in release-plz config

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -28,10 +28,13 @@ version_group = "workspace"
 name = "sapphire-sync"
 version_group = "workspace"
 
-# CLI は publish = false かつ独自バージョンなので release-plz の対象外。
+# CLI は Cargo.toml 側で publish = false かつ独自バージョン管理なので
+# release-plz の対象外。Cargo.toml の publish 設定と整合させるため
+# publish も明示的に false にする。
 [[package]]
 name = "sapphire-workspace-cli"
 release = false
+publish = false
 
 [changelog]
 # 既存 CHANGELOG.md のヘッダーをそのまま維持し、新規エントリは


### PR DESCRIPTION
## Summary
- release-plz が起動時に以下のエラーで失敗していた:
  ```
  Package `sapphire-workspace-cli` has `publish = false` or `publish = []` in the Cargo.toml,
  but it has `publish = true` in the release-plz configuration.
  ```
- release-plz は per-package の `publish` 設定が Cargo.toml と一致するか検証する。`release = false` だけでは `publish` は workspace 既定の `true` を継承してしまうため、CLI の `Cargo.toml` (`publish = false`) と矛盾していた。
- `release-plz.toml` の `sapphire-workspace-cli` セクションに `publish = false` を明示。

## Test plan
- [ ] マージ後、Release-plz workflow がこの validation エラーなしに起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)