### PR TITLE
chore: release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to `sapphire-workspace` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1](https://github.com/fluo10/sapphire-workspace/compare/v0.11.0...v0.11.1) - 2026-05-23
+
+### Fixed
+
+- *(ci)* set publish = false for sapphire-workspace-cli in release-plz config
+- *(ci)* update release-plz action to release-plz/action@v0.5
+
+### Other
+
+- Merge pull request #59 from fluo10/chore/gitignore-ds-store
+- ignore .DS_Store
+
 ## [0.11.0] - 2026-05-16
 
 ### Changed (breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,16 @@ All notable changes to `sapphire-workspace` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.11.1](https://github.com/fluo10/sapphire-workspace/compare/v0.11.0...v0.11.1) - 2026-05-23
+## [0.12.0](https://github.com/fluo10/sapphire-workspace/compare/v0.11.0...v0.12.0) - 2026-05-23
 
-### Fixed
+### Changed
 
-- *(ci)* set publish = false for sapphire-workspace-cli in release-plz config
-- *(ci)* update release-plz action to release-plz/action@v0.5
+- `sapphire-sync`: bump `git2` from 0.20 to 0.21. This pulls in a new major of `libgit2-sys` (a `-sys` crate with a `links` key), released as a minor bump to avoid silent build failures for downstream crates that depend on a different `libgit2-sys` major. See `RELEASING.md` for the `-sys` policy.
 
-### Other
+### Internal
 
-- Merge pull request #59 from fluo10/chore/gitignore-ds-store
-- ignore .DS_Store
+- Adopt release-plz for automated version bumps, CHANGELOG generation, and crates.io publishing.
+- Add `.DS_Store` to `.gitignore`.
 
 ## [0.11.0] - 2026-05-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 description = "Workspace management library for indexing, search, and sync of file-based documents"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-workspace"
@@ -52,8 +52,8 @@ fastembed-embed = ["sapphire-retrieve/fastembed-embed"]
 git-sync        = ["sapphire-sync/git"]
 
 [dependencies]
-sapphire-retrieve = { version = "0.11.0", path = "crates/sapphire-retrieve", default-features = false }
-sapphire-sync     = { version = "0.11.0", path = "crates/sapphire-sync", default-features = false }
+sapphire-retrieve = { version = "0.11.1", path = "crates/sapphire-retrieve", default-features = false }
+sapphire-sync     = { version = "0.11.1", path = "crates/sapphire-sync", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.11.1"
+version = "0.12.0"
 description = "Workspace management library for indexing, search, and sync of file-based documents"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-workspace"
@@ -52,8 +52,8 @@ fastembed-embed = ["sapphire-retrieve/fastembed-embed"]
 git-sync        = ["sapphire-sync/git"]
 
 [dependencies]
-sapphire-retrieve = { version = "0.11.1", path = "crates/sapphire-retrieve", default-features = false }
-sapphire-sync     = { version = "0.11.1", path = "crates/sapphire-sync", default-features = false }
+sapphire-retrieve = { version = "0.12.0", path = "crates/sapphire-retrieve", default-features = false }
+sapphire-sync     = { version = "0.12.0", path = "crates/sapphire-sync", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,48 +1,48 @@
 # Releasing
 
-このリポジトリのリリースは [release-plz](https://release-plz.dev/) で自動化しています。
+Releases for this repository are automated with [release-plz](https://release-plz.dev/).
 
-## 通常運用
+## Normal flow
 
-1. `main` に変更が push されると release-plz が自動で release PR を作成・更新します。
-2. release PR の内容（バージョン、`CHANGELOG.md`、`Cargo.toml`）を確認します。
-3. PR をマージすると、`v{version}` タグ・GitHub release・crates.io への publish が自動で行われ、CLI バイナリも各プラットフォーム向けにビルド・アップロードされます。
+1. When changes are pushed to `main`, release-plz automatically creates or updates a release PR.
+2. Review the release PR (version, `CHANGELOG.md`, `Cargo.toml`).
+3. Merging the PR creates the `v{version}` tag, the GitHub release, publishes to crates.io, and builds CLI binaries for each target platform.
 
-## バージョン決定ルール
+## Version bump rules
 
-release-plz は conventional commits からバージョンを推論します（pre-1.0 の `0.x.y` を前提）。
+release-plz infers the version from conventional commits (assuming pre-1.0 `0.x.y`).
 
-- `feat:` / `fix:` / `chore(deps):` などの非破壊的変更 → patch bump
-- `feat!:` / `chore!:` あるいは commit footer の `BREAKING CHANGE:` → minor bump
-- 自分のコードの公開 API を変更した場合（関数シグネチャ、公開構造体のフィールド等） → minor bump（明示的に `!` を付ける）
+- `feat:` / `fix:` / `chore(deps):` and other non-breaking changes → patch bump
+- `feat!:` / `chore!:` or a `BREAKING CHANGE:` footer → minor bump
+- Public API changes you make yourself (function signatures, public struct fields, etc.) → minor bump (mark the commit with `!`)
 
-エラー型に `#[from] some_crate::Error` で外部 crate を露出している場合、依存メジャー bump は理屈上 breaking ですが、実害がほぼないため通常は patch のままで構いません（コミュニティ的にも pragmatic な扱いが多数派）。
+When an error type re-exposes a foreign crate via `#[from] some_crate::Error`, a major bump of that dependency is technically breaking, but the practical impact is usually nil. Patch is generally fine — this is the pragmatic stance most of the Rust ecosystem takes.
 
-## `-sys` crate 依存更新の特例
+## Special case: `-sys` crate updates
 
-`-sys` crate（`libgit2-sys`, `libsqlite3-sys`, `openssl-sys` など、Cargo.toml に `links = "..."` を持つ crate）のメジャーバージョン更新は **必ず minor bump** にします。
+A major bump of a `-sys` crate (`libgit2-sys`, `libsqlite3-sys`, `openssl-sys`, anything with `links = "..."` in its Cargo.toml) **must** become a minor bump on our side.
 
-理由: Cargo は `links` キーが同じ crate の異なるメジャーバージョンが依存グラフ内に同居することを許しません。patch リリースで `-sys` のメジャーを上げると、別の `-sys` メジャーを使うダウンストリームクレートが build 失敗します（API 互換性ではなく hard error）。
+Reason: Cargo refuses to resolve a dependency graph that contains two different majors of the same `links`-bearing crate. If we ship a patch release that pulls in a new `-sys` major, downstream crates that pin a different `-sys` major fail to build. This is a hard error, not an API compatibility break, and the user cannot work around it.
 
-[Cargo SemVer guide の `-sys` セクション](https://doc.rust-lang.org/cargo/reference/semver.html) でも明示的に major change として扱われています。
+The [Cargo SemVer guide's `-sys` section](https://doc.rust-lang.org/cargo/reference/semver.html) explicitly treats this as a major change.
 
-### 対象になる依存（例）
+### Dependencies to watch for
 
-このリポジトリで `-sys` を引き込んでいる主な依存:
+`-sys` crates currently reachable from this workspace:
 
 - `git2` → `libgit2-sys`
 - `rusqlite` → `libsqlite3-sys`
-- `lancedb` の連鎖依存に `arrow-*` 経由で複数の `-sys` クレートが含まれることあり
+- `lancedb` may transitively pull in additional `-sys` crates through `arrow-*`
 
-### 手順
+### How to handle it
 
-依存更新の release PR が出てきたら CHANGELOG を確認し、上記カテゴリの crate が含まれていれば：
+When a release PR includes a dependency update, check the CHANGELOG. If any of the above are involved:
 
-1. PR のブランチに直接 push して `Cargo.toml` の `workspace.package.version` と関連する内部依存指定を patch から minor に書き換える
-2. `CHANGELOG.md` の該当バージョン見出し（および compare URL）も合わせて書き換える
-3. 理由を CHANGELOG エントリに一行添える（例: 「pulls in a new major of `libgit2-sys`」）
+1. Push to the release PR branch and change `workspace.package.version` in `Cargo.toml` (and the matching internal dependency versions) from patch to minor.
+2. Update the version heading (and the compare URL) in `CHANGELOG.md` (and any per-crate `CHANGELOG.md`) to match.
+3. Add a one-line note to the CHANGELOG entry explaining why (e.g. "pulls in a new major of `libgit2-sys`").
 
-## 必要な secrets
+## Required secrets
 
-- `RELEASE_PLZ_TOKEN`: fine-grained PAT、Contents + Pull requests の read/write
-- `CARGO_REGISTRY_TOKEN`: crates.io publish 用
+- `RELEASE_PLZ_TOKEN`: fine-grained PAT with Contents + Pull requests read/write.
+- `CARGO_REGISTRY_TOKEN`: used for crates.io publishing.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,48 @@
+# Releasing
+
+このリポジトリのリリースは [release-plz](https://release-plz.dev/) で自動化しています。
+
+## 通常運用
+
+1. `main` に変更が push されると release-plz が自動で release PR を作成・更新します。
+2. release PR の内容（バージョン、`CHANGELOG.md`、`Cargo.toml`）を確認します。
+3. PR をマージすると、`v{version}` タグ・GitHub release・crates.io への publish が自動で行われ、CLI バイナリも各プラットフォーム向けにビルド・アップロードされます。
+
+## バージョン決定ルール
+
+release-plz は conventional commits からバージョンを推論します（pre-1.0 の `0.x.y` を前提）。
+
+- `feat:` / `fix:` / `chore(deps):` などの非破壊的変更 → patch bump
+- `feat!:` / `chore!:` あるいは commit footer の `BREAKING CHANGE:` → minor bump
+- 自分のコードの公開 API を変更した場合（関数シグネチャ、公開構造体のフィールド等） → minor bump（明示的に `!` を付ける）
+
+エラー型に `#[from] some_crate::Error` で外部 crate を露出している場合、依存メジャー bump は理屈上 breaking ですが、実害がほぼないため通常は patch のままで構いません（コミュニティ的にも pragmatic な扱いが多数派）。
+
+## `-sys` crate 依存更新の特例
+
+`-sys` crate（`libgit2-sys`, `libsqlite3-sys`, `openssl-sys` など、Cargo.toml に `links = "..."` を持つ crate）のメジャーバージョン更新は **必ず minor bump** にします。
+
+理由: Cargo は `links` キーが同じ crate の異なるメジャーバージョンが依存グラフ内に同居することを許しません。patch リリースで `-sys` のメジャーを上げると、別の `-sys` メジャーを使うダウンストリームクレートが build 失敗します（API 互換性ではなく hard error）。
+
+[Cargo SemVer guide の `-sys` セクション](https://doc.rust-lang.org/cargo/reference/semver.html) でも明示的に major change として扱われています。
+
+### 対象になる依存（例）
+
+このリポジトリで `-sys` を引き込んでいる主な依存:
+
+- `git2` → `libgit2-sys`
+- `rusqlite` → `libsqlite3-sys`
+- `lancedb` の連鎖依存に `arrow-*` 経由で複数の `-sys` クレートが含まれることあり
+
+### 手順
+
+依存更新の release PR が出てきたら CHANGELOG を確認し、上記カテゴリの crate が含まれていれば：
+
+1. PR のブランチに直接 push して `Cargo.toml` の `workspace.package.version` と関連する内部依存指定を patch から minor に書き換える
+2. `CHANGELOG.md` の該当バージョン見出し（および compare URL）も合わせて書き換える
+3. 理由を CHANGELOG エントリに一行添える（例: 「pulls in a new major of `libgit2-sys`」）
+
+## 必要な secrets
+
+- `RELEASE_PLZ_TOKEN`: fine-grained PAT、Contents + Pull requests の read/write
+- `CARGO_REGISTRY_TOKEN`: crates.io publish 用

--- a/crates/sapphire-retrieve/CHANGELOG.md
+++ b/crates/sapphire-retrieve/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to `sapphire-workspace` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/crates/sapphire-sync/CHANGELOG.md
+++ b/crates/sapphire-sync/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to `sapphire-workspace` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [0.11.1](https://github.com/fluo10/sapphire-workspace/compare/sapphire-sync-v0.11.0...sapphire-sync-v0.11.1) - 2026-05-23
+
+### Other
+
+- *(deps)* Update git2 requirement from 0.20 to 0.21

--- a/crates/sapphire-sync/CHANGELOG.md
+++ b/crates/sapphire-sync/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.11.1](https://github.com/fluo10/sapphire-workspace/compare/sapphire-sync-v0.11.0...sapphire-sync-v0.11.1) - 2026-05-23
+## [0.12.0](https://github.com/fluo10/sapphire-workspace/compare/sapphire-sync-v0.11.0...sapphire-sync-v0.12.0) - 2026-05-23
 
-### Other
+### Changed
 
-- *(deps)* Update git2 requirement from 0.20 to 0.21
+- Bump `git2` from 0.20 to 0.21. This pulls in a new major of `libgit2-sys` (a `-sys` crate with a `links` key); released as a minor bump (not patch) to prevent build failures for downstream crates that depend on a different `libgit2-sys` major.

--- a/crates/sapphire-workspace-cli/Cargo.toml
+++ b/crates/sapphire-workspace-cli/Cargo.toml
@@ -19,7 +19,7 @@ fastembed-embed = ["sapphire-workspace/fastembed-embed"]
 git-sync        = ["sapphire-workspace/git-sync"]
 
 [dependencies]
-sapphire-workspace = { version = "0.11.0", path = "../..", default-features = false }
+sapphire-workspace = { version = "0.11.1", path = "../..", default-features = false }
 clap.workspace = true
 anyhow.workspace = true
 serde.workspace = true

--- a/crates/sapphire-workspace-cli/Cargo.toml
+++ b/crates/sapphire-workspace-cli/Cargo.toml
@@ -19,7 +19,7 @@ fastembed-embed = ["sapphire-workspace/fastembed-embed"]
 git-sync        = ["sapphire-workspace/git-sync"]
 
 [dependencies]
-sapphire-workspace = { version = "0.11.1", path = "../..", default-features = false }
+sapphire-workspace = { version = "0.12.0", path = "../..", default-features = false }
 clap.workspace = true
 anyhow.workspace = true
 serde.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `sapphire-sync`: 0.11.0 -> 0.11.1 (✓ API compatible changes)
* `sapphire-retrieve`: 0.11.0 -> 0.11.1
* `sapphire-workspace`: 0.11.0 -> 0.11.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `sapphire-sync`

<blockquote>

## [0.11.1](https://github.com/fluo10/sapphire-workspace/compare/sapphire-sync-v0.11.0...sapphire-sync-v0.11.1) - 2026-05-23

### Other

- *(deps)* Update git2 requirement from 0.20 to 0.21
</blockquote>


## `sapphire-workspace`

<blockquote>

## [0.11.1](https://github.com/fluo10/sapphire-workspace/compare/v0.11.0...v0.11.1) - 2026-05-23

### Fixed

- *(ci)* set publish = false for sapphire-workspace-cli in release-plz config
- *(ci)* update release-plz action to release-plz/action@v0.5

### Other

- Merge pull request #59 from fluo10/chore/gitignore-ds-store
- ignore .DS_Store
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).