### PR TITLE
chore: release v0.12.0

### DIFF
--- a/crates/sapphire-retrieve/CHANGELOG.md
+++ b/crates/sapphire-retrieve/CHANGELOG.md
@@ -5,3 +5,9 @@ All notable changes to `sapphire-workspace` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.12.0](https://github.com/fluo10/sapphire-workspace/compare/sapphire-retrieve-v0.11.0...sapphire-retrieve-v0.12.0) - 2026-05-23
+
+### Other
+
+- release v0.11.1


### PR DESCRIPTION



## 🤖 New release

* `sapphire-sync`: 0.11.0 -> 0.12.0
* `sapphire-retrieve`: 0.11.0 -> 0.12.0
* `sapphire-workspace`: 0.11.0 -> 0.12.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `sapphire-sync`

<blockquote>

## [0.12.0](https://github.com/fluo10/sapphire-workspace/compare/sapphire-sync-v0.11.0...sapphire-sync-v0.12.0) - 2026-05-23

### Changed

- Bump `git2` from 0.20 to 0.21. This pulls in a new major of `libgit2-sys` (a `-sys` crate with a `links` key); released as a minor bump (not patch) to prevent build failures for downstream crates that depend on a different `libgit2-sys` major.
</blockquote>

## `sapphire-retrieve`

<blockquote>

## [0.12.0](https://github.com/fluo10/sapphire-workspace/compare/sapphire-retrieve-v0.11.0...sapphire-retrieve-v0.12.0) - 2026-05-23

### Other

- release v0.11.1
</blockquote>

## `sapphire-workspace`

<blockquote>

## [0.12.0](https://github.com/fluo10/sapphire-workspace/compare/v0.11.0...v0.12.0) - 2026-05-23

### Changed

- `sapphire-sync`: bump `git2` from 0.20 to 0.21. This pulls in a new major of `libgit2-sys` (a `-sys` crate with a `links` key), released as a minor bump to avoid silent build failures for downstream crates that depend on a different `libgit2-sys` major. See `RELEASING.md` for the `-sys` policy.

### Internal

- Adopt release-plz for automated version bumps, CHANGELOG generation, and crates.io publishing.
- Add `.DS_Store` to `.gitignore`.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).