### PR TITLE
fix(sync): enable git2 ssh/https features explicitly

### DIFF
--- a/crates/sapphire-sync/Cargo.toml
+++ b/crates/sapphire-sync/Cargo.toml
@@ -20,4 +20,4 @@ serde_json.workspace = true
 chrono = { workspace = true }
 uuid = { workspace = true }
 dirs = { workspace = true, optional = true }
-git2 = { version = "0.21", optional = true }
+git2 = { version = "0.21", default-features = false, features = ["ssh", "https"], optional = true }


### PR DESCRIPTION
## Summary
- `git2` 0.20+ で default features から `ssh` / `https` が外れた影響で、`sapphire-sync` がビルドする libgit2 に libssh2/TLS がリンクされず、SSH・HTTPS リモートに対する fetch/push が実行時に失敗する状態だった
- [crates/sapphire-sync/src/git_sync.rs](crates/sapphire-sync/src/git_sync.rs) が `Cred::ssh_key_from_agent` / `Cred::ssh_key` を使うため、両 feature を明示的に有効化

## Test plan
- [x] `cargo build -p sapphire-sync` が通る
- [x] `cargo tree -p sapphire-sync -e features` で `git2 feature "ssh"` / `"https"` および `libssh2-sys` / `openssl-sys` が依存ツリーに含まれることを確認
- [ ] 実環境で SSH リモートに対する `GitSync` の fetch/push が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)