### PR TITLE
chore: release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `sapphire-workspace` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [0.12.0](https://github.com/fluo10/sapphire-workspace/compare/v0.11.0...v0.12.0) - 2026-05-23
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 description = "Workspace management library for indexing, search, and sync of file-based documents"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-workspace"
@@ -52,8 +52,8 @@ fastembed-embed = ["sapphire-retrieve/fastembed-embed"]
 git-sync        = ["sapphire-sync/git"]
 
 [dependencies]
-sapphire-retrieve = { version = "0.12.0", path = "crates/sapphire-retrieve", default-features = false }
-sapphire-sync     = { version = "0.12.0", path = "crates/sapphire-sync", default-features = false }
+sapphire-retrieve = { version = "0.12.1", path = "crates/sapphire-retrieve", default-features = false }
+sapphire-sync     = { version = "0.12.1", path = "crates/sapphire-sync", default-features = false }
 thiserror.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/sapphire-sync/CHANGELOG.md
+++ b/crates/sapphire-sync/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.12.1](https://github.com/fluo10/sapphire-workspace/compare/sapphire-sync-v0.12.0...sapphire-sync-v0.12.1) - 2026-05-24
+
+### Fixed
+
+- *(sync)* enable git2 ssh/https features explicitly
+
 ## [0.12.0](https://github.com/fluo10/sapphire-workspace/compare/sapphire-sync-v0.11.0...sapphire-sync-v0.12.0) - 2026-05-23
 
 ### Changed

--- a/crates/sapphire-workspace-cli/Cargo.toml
+++ b/crates/sapphire-workspace-cli/Cargo.toml
@@ -19,7 +19,7 @@ fastembed-embed = ["sapphire-workspace/fastembed-embed"]
 git-sync        = ["sapphire-workspace/git-sync"]
 
 [dependencies]
-sapphire-workspace = { version = "0.12.0", path = "../..", default-features = false }
+sapphire-workspace = { version = "0.12.1", path = "../..", default-features = false }
 clap.workspace = true
 anyhow.workspace = true
 serde.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `sapphire-sync`: 0.12.0 -> 0.12.1 (✓ API compatible changes)
* `sapphire-retrieve`: 0.12.0 -> 0.12.1
* `sapphire-workspace`: 0.12.0 -> 0.12.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `sapphire-sync`

<blockquote>

## [0.12.1](https://github.com/fluo10/sapphire-workspace/compare/sapphire-sync-v0.12.0...sapphire-sync-v0.12.1) - 2026-05-24

### Fixed

- *(sync)* enable git2 ssh/https features explicitly
</blockquote>


## `sapphire-workspace`

<blockquote>

## [0.12.0](https://github.com/fluo10/sapphire-workspace/compare/v0.11.0...v0.12.0) - 2026-05-23

### Changed

- `sapphire-sync`: bump `git2` from 0.20 to 0.21. This pulls in a new major of `libgit2-sys` (a `-sys` crate with a `links` key), released as a minor bump to avoid silent build failures for downstream crates that depend on a different `libgit2-sys` major. See `RELEASING.md` for the `-sys` policy.

### Internal

- Adopt release-plz for automated version bumps, CHANGELOG generation, and crates.io publishing.
- Add `.DS_Store` to `.gitignore`.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).