### PR TITLE
feat(retrieve): add TOML file support with single-chunk indexing

### DIFF
--- a/crates/sapphire-retrieve/src/chunker.rs
+++ b/crates/sapphire-retrieve/src/chunker.rs
@@ -6,6 +6,8 @@
 //! - [`MarkdownChunker`] — paragraph-based chunker for Markdown/plain-text files.
 //! - [`JsonlChunker`] — line-based chunker for JSONL files (one JSON object
 //!   per line; AI conversation logs from apps such as SillyTavern, etc.).
+//! - [`TomlChunker`] — whole-file chunker for TOML config files (always
+//!   returns a single chunk).
 //!
 //! # Source positions
 //!
@@ -213,6 +215,36 @@ impl Chunker for JsonlChunker {
         } else {
             chunks
         }
+    }
+}
+
+// ── TomlChunker ───────────────────────────────────────────────────────────────
+
+/// Whole-file chunker for TOML configuration files.
+///
+/// Always returns exactly one chunk covering the entire file body.  Embedding
+/// a TOML file as a single unit keeps related keys/sections together, which is
+/// usually what callers want when retrieving configuration.
+pub struct TomlChunker;
+
+impl Chunker for TomlChunker {
+    fn chunk(&self, title: &str, content: &str) -> Vec<TextChunk> {
+        let trimmed = content.trim();
+        if trimmed.is_empty() {
+            return vec![TextChunk {
+                line_start: 0,
+                line_end: 0,
+                text: title.to_owned(),
+            }];
+        }
+        let leading = &content[..content.len() - content.trim_start().len()];
+        let line_start = count_newlines(leading);
+        let line_end = line_start + count_newlines(trimmed);
+        vec![TextChunk {
+            line_start,
+            line_end,
+            text: normalise(content),
+        }]
     }
 }
 
@@ -434,6 +466,38 @@ mod tests {
         let chunks = c.chunk("empty.jsonl", "");
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].text, "empty.jsonl");
+    }
+
+    // ── TomlChunker ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn toml_single_chunk() {
+        let c = TomlChunker;
+        let toml = "[package]\nname = \"foo\"\nversion = \"1.0\"\n\n[deps]\nbar = \"2\"";
+        let chunks = c.chunk("Cargo.toml", toml);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].line_start, 0);
+        assert_eq!(chunks[0].line_end, 5);
+        assert!(chunks[0].text.contains("[package]"));
+        assert!(chunks[0].text.contains("[deps]"));
+        assert!(!chunks[0].text.contains("\n\n"));
+    }
+
+    #[test]
+    fn toml_empty_body_returns_title() {
+        let c = TomlChunker;
+        let chunks = c.chunk("Cargo.toml", "");
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].text, "Cargo.toml");
+    }
+
+    #[test]
+    fn toml_leading_blank_lines() {
+        let c = TomlChunker;
+        let chunks = c.chunk("Cargo.toml", "\n\n[a]\nx = 1");
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].line_start, 2);
+        assert_eq!(chunks[0].line_end, 3);
     }
 
     #[test]

--- a/crates/sapphire-retrieve/src/lib.rs
+++ b/crates/sapphire-retrieve/src/lib.rs
@@ -10,7 +10,7 @@ pub mod retrieve_store;
 pub mod sqlite_store;
 pub mod vector_store;
 
-pub use chunker::{Chunker, JsonlChunker, MarkdownChunker, TextChunk};
+pub use chunker::{Chunker, JsonlChunker, MarkdownChunker, TextChunk, TomlChunker};
 pub use config::{EmbeddingConfig, HybridConfig, RetrieveConfig, VectorDb};
 pub use db::open_in_memory;
 #[cfg(feature = "lancedb-store")]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, path::Path, sync::Arc};
 
-use sapphire_retrieve::{Chunker, Document, JsonlChunker, RetrieveStore};
+use sapphire_retrieve::{Chunker, Document, JsonlChunker, RetrieveStore, TomlChunker};
 
 use crate::{error::Result, workspace::Workspace};
 
@@ -18,6 +18,7 @@ fn file_mtime_secs(path: &Path) -> i64 {
 
 const MARKDOWN_EXTENSIONS: &[&str] = &["md", "markdown", "txt", "rst", "org"];
 const JSONL_EXTENSIONS: &[&str] = &["jsonl"];
+const TOML_EXTENSIONS: &[&str] = &["toml"];
 
 /// Generate a stable `i64` document ID from a file path (FNV-1a).
 pub fn path_to_doc_id(path: &Path) -> i64 {
@@ -41,6 +42,7 @@ pub fn path_to_doc_id(path: &Path) -> i64 {
 /// |-----------|----------|-----------------------|
 /// | `md`, `markdown`, `txt`, `rst`, `org` | paragraph split | start/end line of paragraph |
 /// | `jsonl` | one message per line | `line_start == line_end` |
+/// | `toml` | single whole-file chunk | first/last non-blank line |
 pub fn sync_workspace(
     workspace: &Workspace,
     retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
@@ -79,8 +81,9 @@ pub fn sync_workspace(
 
         let is_markdown = MARKDOWN_EXTENSIONS.contains(&ext.as_str());
         let is_jsonl = JSONL_EXTENSIONS.contains(&ext.as_str());
+        let is_toml = TOML_EXTENSIONS.contains(&ext.as_str());
 
-        if !is_markdown && !is_jsonl {
+        if !is_markdown && !is_jsonl && !is_toml {
             continue;
         }
 
@@ -91,12 +94,16 @@ pub fn sync_workspace(
 
         let doc_id = path_to_doc_id(path);
 
-        let doc = if is_jsonl {
+        let doc = if is_jsonl || is_toml {
             let file_name = path
                 .file_name()
                 .map(|n| n.to_string_lossy().into_owned())
                 .unwrap_or_default();
-            let text_chunks = JsonlChunker.chunk(&file_name, &raw);
+            let text_chunks = if is_jsonl {
+                JsonlChunker.chunk(&file_name, &raw)
+            } else {
+                TomlChunker.chunk(&file_name, &raw)
+            };
             let body = text_chunks
                 .iter()
                 .map(|c| c.text.as_str())
@@ -189,8 +196,9 @@ pub fn sync_workspace_incremental(
 
         let is_markdown = MARKDOWN_EXTENSIONS.contains(&ext.as_str());
         let is_jsonl = JSONL_EXTENSIONS.contains(&ext.as_str());
+        let is_toml = TOML_EXTENSIONS.contains(&ext.as_str());
 
-        if !is_markdown && !is_jsonl {
+        if !is_markdown && !is_jsonl && !is_toml {
             continue;
         }
 
@@ -211,12 +219,16 @@ pub fn sync_workspace_incremental(
             Err(_) => continue,
         };
 
-        let doc = if is_jsonl {
+        let doc = if is_jsonl || is_toml {
             let file_name = path
                 .file_name()
                 .map(|n| n.to_string_lossy().into_owned())
                 .unwrap_or_default();
-            let text_chunks = JsonlChunker.chunk(&file_name, &raw);
+            let text_chunks = if is_jsonl {
+                JsonlChunker.chunk(&file_name, &raw)
+            } else {
+                TomlChunker.chunk(&file_name, &raw)
+            };
             let body = text_chunks
                 .iter()
                 .map(|c| c.text.as_str())

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -7,7 +7,7 @@ use sapphire_retrieve::db::SCHEMA_VERSION;
 use sapphire_retrieve::open_lancedb;
 use sapphire_retrieve::{
     Chunker, Document, Embedder, FileSearchResult, FtsQuery, HybridQuery, JsonlChunker,
-    RetrieveStore, VectorQuery,
+    RetrieveStore, TomlChunker, VectorQuery,
 };
 #[cfg(feature = "sqlite-store")]
 use sapphire_retrieve::{open_sqlite_fts, open_sqlite_vec};
@@ -328,8 +328,9 @@ impl WorkspaceState {
     /// JSONL files are pre-chunked line-by-line so that an append only
     /// produces new chunks at the tail; existing lines retain their
     /// `(doc_id, line_start)` identity in the chunk store and are not
-    /// re-embedded.  Other file types fall through to the storage layer's
-    /// default paragraph chunker.
+    /// re-embedded.  TOML files are stored as a single whole-file chunk.
+    /// Other file types fall through to the storage layer's default
+    /// paragraph chunker.
     pub fn on_file_updated(&self, path: &Path) -> Result<()> {
         let resolved = self.resolve_path(path)?;
         if !resolved.is_internal() {
@@ -351,18 +352,23 @@ impl WorkspaceState {
         let body = std::fs::read_to_string(abs)?;
         let doc_id = path_to_doc_id(abs);
 
-        let is_jsonl = abs
+        let ext = abs
             .extension()
             .and_then(|e| e.to_str())
-            .map(|e| e.eq_ignore_ascii_case("jsonl"))
-            .unwrap_or(false);
+            .map(|e| e.to_ascii_lowercase());
+        let is_jsonl = ext.as_deref() == Some("jsonl");
+        let is_toml = ext.as_deref() == Some("toml");
 
-        let doc = if is_jsonl {
+        let doc = if is_jsonl || is_toml {
             let file_name = abs
                 .file_name()
                 .map(|n| n.to_string_lossy().into_owned())
                 .unwrap_or_default();
-            let text_chunks = JsonlChunker.chunk(&file_name, &body);
+            let text_chunks = if is_jsonl {
+                JsonlChunker.chunk(&file_name, &body)
+            } else {
+                TomlChunker.chunk(&file_name, &body)
+            };
             let stored_body = text_chunks
                 .iter()
                 .map(|c| c.text.as_str())


### PR DESCRIPTION
## Summary
- Add `TomlChunker` in `sapphire-retrieve` that emits a single whole-file chunk so `.toml` configs stay searchable as a unit
- Wire `.toml` through `indexer.rs` (full and incremental sync) and `workspace_state.rs::on_file_updated`
- Cover the new chunker with 3 unit tests (single-chunk content, empty body falls back to title, leading-blank-line handling)

## Test plan
- [x] `cargo build --all-features`
- [x] `cargo test -p sapphire-retrieve --lib chunker::` (18 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)