### PR TITLE
feat(indexer): hook-driven incremental sync API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,6 @@ walkdir = "2"
 uuid.workspace = true
 chrono = { workspace = true }
 md-5 = "0.11"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 use crate::{error::Result, workspace::Workspace};
 
 /// Return the mtime of `path` as seconds since UNIX epoch, or 0 on error.
-fn file_mtime_secs(path: &Path) -> i64 {
+pub(crate) fn file_mtime_secs(path: &Path) -> i64 {
     path.metadata()
         .and_then(|m| m.modified())
         .map(|t| {
@@ -25,6 +25,19 @@ const MARKDOWN_EXTENSIONS: &[&str] = &["md", "markdown", "txt", "rst", "org"];
 const JSONL_EXTENSIONS: &[&str] = &["jsonl"];
 const TOML_EXTENSIONS: &[&str] = &["toml"];
 
+/// `true` if `path` has an extension the indexer recognises (markdown family,
+/// JSONL, or TOML).
+pub(crate) fn is_indexable_path(path: &Path) -> bool {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+    MARKDOWN_EXTENSIONS.contains(&ext.as_str())
+        || JSONL_EXTENSIONS.contains(&ext.as_str())
+        || TOML_EXTENSIONS.contains(&ext.as_str())
+}
+
 /// Generate a stable `i64` document ID from a file path (FNV-1a).
 pub fn path_to_doc_id(path: &Path) -> i64 {
     const OFFSET: u64 = 14695981039346656037;
@@ -37,12 +50,14 @@ pub fn path_to_doc_id(path: &Path) -> i64 {
     h as i64
 }
 
-/// Build a [`Document`] for `path` using the extension-default chunking.
+/// Build a [`Document`] for `path` by reading the file from disk and applying
+/// the extension-based chunking (paragraph / per-line / whole-file).
 ///
-/// Returns `None` if the file cannot be read (mirrors the silent-skip behavior
-/// of the legacy [`sync_workspace_incremental`]).
-fn build_default_document(path: &Path, doc_id: i64) -> Option<Document> {
-    let raw = std::fs::read_to_string(path).ok()?;
+/// Returns the `io::Error` from `read_to_string` if the file cannot be read.
+/// Bulk walkers call this and silently drop failures via `.ok()`; the
+/// single-file `on_file_updated_*` methods propagate the error.
+pub(crate) fn build_document_from_disk(path: &Path, doc_id: i64) -> std::io::Result<Document> {
+    let raw = std::fs::read_to_string(path)?;
 
     let ext = path
         .extension()
@@ -89,7 +104,7 @@ fn build_default_document(path: &Path, doc_id: i64) -> Option<Document> {
         }
     };
 
-    Some(doc)
+    Ok(doc)
 }
 
 /// Recursively walk `workspace` and upsert all text files into `retrieve_db`.
@@ -107,101 +122,38 @@ pub fn sync_workspace(
     workspace: &Workspace,
     retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
 ) -> Result<(usize, usize)> {
-    let existing_ids: HashSet<i64> = retrieve_db
-        .document_ids()
-        .unwrap_or_default()
-        .into_iter()
-        .collect();
-
-    let mut current_ids: HashSet<i64> = HashSet::new();
-    let mut upserted = 0;
-
-    for entry in walkdir::WalkDir::new(&workspace.root)
-        .follow_links(false)
-        .into_iter()
-        .filter_entry(|e| {
-            if e.file_type().is_dir() {
-                !e.file_name().to_string_lossy().starts_with('.')
-            } else {
-                true
-            }
-        })
-    {
-        let entry = entry?;
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        let path = entry.path();
-
-        let ext = path
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("")
-            .to_lowercase();
-
-        let is_markdown = MARKDOWN_EXTENSIONS.contains(&ext.as_str());
-        let is_jsonl = JSONL_EXTENSIONS.contains(&ext.as_str());
-        let is_toml = TOML_EXTENSIONS.contains(&ext.as_str());
-
-        if !is_markdown && !is_jsonl && !is_toml {
-            continue;
-        }
-
-        let doc_id = path_to_doc_id(path);
-        let Some(doc) = build_default_document(path, doc_id) else {
-            continue;
-        };
-
-        retrieve_db.upsert_document(&doc)?;
-        current_ids.insert(doc_id);
-        upserted += 1;
-    }
-
-    retrieve_db.rebuild_fts()?;
-
-    let mut removed = 0;
-    for id in &existing_ids {
-        if !current_ids.contains(id) {
-            retrieve_db.remove_document(*id)?;
-            removed += 1;
-        }
-    }
-    if removed > 0 {
-        retrieve_db.rebuild_fts()?;
-    }
-
-    Ok((upserted, removed))
+    let mut hook = NoopHook;
+    let report =
+        sync_workspace_full_with_hook(workspace, retrieve_db, &mut hook).map_err(|e| match e {
+            SyncWithHookError::Workspace(e) => e,
+            SyncWithHookError::Hook(never) => match never {},
+        })?;
+    Ok((report.upserted, report.removed))
 }
 
-// ── hook-driven incremental sync ──────────────────────────────────────────────
+// ── hook-driven sync ─────────────────────────────────────────────────────────
 
-/// Callback hook invoked during incremental sync.
+/// Callback hook invoked during a sync run, used by external callers (e.g.
+/// sapphire-journal) to update their own per-file caches alongside the
+/// workspace's retrieve index.
 ///
-/// The workspace owns the walk, mtime read, default `Document` construction,
-/// and all writes to the retrieve DB. The hook gets to (a) override the
-/// `Document` construction for files it recognizes (e.g. parse frontmatter)
-/// and update its own caches, and (b) react to file removals.
+/// The hook is a **side channel**: the workspace always reads the file from
+/// disk and constructs the [`Document`] itself. The hook does not see or
+/// modify the indexed body. Its only job is to update the calling
+/// application's own DB at the same point in time the workspace is touching
+/// a file.
 ///
-/// See [`sync_workspace_with_hook`].
+/// See [`sync_workspace_with_hook`] / [`sync_workspace_full_with_hook`].
 pub trait IndexHook {
     /// Error type the hook can produce. Surfaces through [`SyncWithHookError::Hook`].
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// Called when a file is new or its mtime changed, after the workspace
-    /// has decided the file is in scope (matching extension etc.).
-    ///
-    /// - `Ok(Some(doc))` → the workspace uses *this* `Document` for
-    ///   `upsert_document`, instead of building one from the raw file body.
-    ///   The hook is expected to have updated its own caches/tables already.
-    /// - `Ok(None)` → the workspace falls back to its default `Document`
-    ///   construction (read file body, chunk by extension, upsert). This is
-    ///   the path for files the hook doesn't recognize but still wants
-    ///   indexed for plain-text search.
-    fn on_changed(
-        &mut self,
-        path: &Path,
-        disk_mtime: i64,
-    ) -> std::result::Result<Option<Document>, Self::Error>;
+    /// has decided the file is in scope (matching extension etc.). The
+    /// workspace will read the file from disk and upsert it into the retrieve
+    /// DB regardless of what this method does — return `Ok(())` for the
+    /// normal case.
+    fn on_changed(&mut self, path: &Path, disk_mtime: i64) -> std::result::Result<(), Self::Error>;
 
     /// Called for each path that was in retrieve DB but is gone from disk,
     /// **before** the workspace removes its document/file row. The hook can
@@ -209,21 +161,21 @@ pub trait IndexHook {
     fn on_removed(&mut self, path: &str) -> std::result::Result<(), Self::Error>;
 
     /// Called once after all changed/removed files have been processed but
-    /// before the final `rebuild_fts`. Suitable for batch validation
-    /// or for the caller to commit its own DB transaction.
+    /// before the final `rebuild_fts`. Suitable for batch validation or for
+    /// the caller to commit its own DB transaction.
     fn after_sweep(&mut self) -> std::result::Result<(), Self::Error> {
         Ok(())
     }
 }
 
-/// Summary of a single [`sync_workspace_with_hook`] run.
+/// Summary of a single hook-driven sync call.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct SyncReport {
     pub upserted: usize,
     pub removed: usize,
 }
 
-/// Error returned by [`sync_workspace_with_hook`].
+/// Error returned by hook-aware sync entry points.
 ///
 /// Wraps either an error originating in the workspace itself or one returned
 /// by the [`IndexHook`], without forcing hook errors through the crate's
@@ -238,47 +190,15 @@ pub enum SyncWithHookError<E: std::error::Error + Send + Sync + 'static> {
     Hook(#[source] E),
 }
 
-/// Hook-driven incremental sync.
+/// Collect all in-scope candidate file paths under `root`.
 ///
-/// Walks `workspace.root` with the same extension set and `.`-hidden filter
-/// as [`sync_workspace_incremental`]. The hook is invoked per file but the
-/// workspace remains in charge of file enumeration, mtime tracking, and
-/// retrieve DB writes.
-///
-/// ## Phases
-///
-/// 1. **Collect candidates.** Walk the tree once and gather every in-scope
-///    file path into a vec before invoking the hook. This guarantees that
-///    file renames performed inside [`IndexHook::on_changed`] cannot perturb
-///    the in-flight walk.
-/// 2. **Per-file dispatch.** For each candidate, compare disk mtime against
-///    the cached value. If unchanged, skip. Otherwise call
-///    [`IndexHook::on_changed`]:
-///    - `Some(doc)` → workspace runs
-///      `upsert_file(path, disk_mtime) + upsert_document(&doc)`.
-///    - `None` → workspace builds a default `Document` from the file body
-///      and runs the same two upserts.
-/// 3. **Removals.** For each path in the retrieve DB that no longer appears
-///    on disk, call [`IndexHook::on_removed`] **before** `remove_file` /
-///    `remove_document`.
-/// 4. **`after_sweep`.** Called once, after all upserts and removals, before
-///    the final `rebuild_fts`.
-/// 5. **`rebuild_fts`** is run once if anything was upserted or removed.
-pub fn sync_workspace_with_hook<H: IndexHook>(
-    workspace: &Workspace,
-    retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
-    hook: &mut H,
-) -> std::result::Result<SyncReport, SyncWithHookError<H::Error>> {
-    let known_mtimes = retrieve_db.file_mtimes().map_err(crate::Error::from)?;
-    let existing_ids: HashSet<i64> = retrieve_db
-        .document_ids()
-        .map_err(crate::Error::from)?
-        .into_iter()
-        .collect();
-
-    // Phase 1: collect all in-scope candidate paths.
-    let mut candidates: Vec<PathBuf> = Vec::new();
-    for entry in walkdir::WalkDir::new(&workspace.root)
+/// Phase 1 of the two-phase walk used by [`sync_workspace_with_hook`] /
+/// [`sync_workspace_full_with_hook`]. Doing all enumeration up front means
+/// that file renames performed inside [`IndexHook::on_changed`] cannot
+/// perturb an in-flight walk.
+fn collect_candidates(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    for entry in walkdir::WalkDir::new(root)
         .follow_links(false)
         .into_iter()
         .filter_entry(|e| {
@@ -289,31 +209,73 @@ pub fn sync_workspace_with_hook<H: IndexHook>(
             }
         })
     {
-        let entry = entry.map_err(crate::Error::from)?;
+        let entry = entry?;
         if !entry.file_type().is_file() {
             continue;
         }
-        let path = entry.path();
-        let ext = path
-            .extension()
-            .and_then(|e| e.to_str())
-            .unwrap_or("")
-            .to_lowercase();
-
-        let is_markdown = MARKDOWN_EXTENSIONS.contains(&ext.as_str());
-        let is_jsonl = JSONL_EXTENSIONS.contains(&ext.as_str());
-        let is_toml = TOML_EXTENSIONS.contains(&ext.as_str());
-
-        if is_markdown || is_jsonl || is_toml {
-            candidates.push(path.to_path_buf());
+        if is_indexable_path(entry.path()) {
+            out.push(entry.path().to_path_buf());
         }
     }
+    Ok(out)
+}
+
+/// Hook-driven **incremental** sync.
+///
+/// Walks `workspace.root` with the same extension set and `.`-hidden filter
+/// as [`sync_workspace_incremental`]. Files whose mtime matches the value in
+/// the retrieve DB are skipped (hook is not invoked for them).
+///
+/// ## Phases
+///
+/// 1. Collect every in-scope candidate path into a vec.
+/// 2. Per file: compare disk mtime against the cached value; if unchanged,
+///    skip. Otherwise call [`IndexHook::on_changed`], read the file and
+///    upsert it.
+/// 3. For each path the DB knows about that is gone from disk: call
+///    [`IndexHook::on_removed`], then `remove_file` + `remove_document`.
+/// 4. [`IndexHook::after_sweep`] is called once before `rebuild_fts`.
+/// 5. `rebuild_fts` runs once if anything was upserted or removed.
+pub fn sync_workspace_with_hook<H: IndexHook>(
+    workspace: &Workspace,
+    retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
+    hook: &mut H,
+) -> std::result::Result<SyncReport, SyncWithHookError<H::Error>> {
+    sync_inner(workspace, retrieve_db, hook, /* full = */ false)
+}
+
+/// Hook-driven **full** sync.
+///
+/// Like [`sync_workspace_with_hook`] but re-indexes every file regardless of
+/// mtime. Use when callers need a full rebuild (e.g. after a schema migration
+/// or a manual cache wipe) and still want their app DB updated in lockstep.
+pub fn sync_workspace_full_with_hook<H: IndexHook>(
+    workspace: &Workspace,
+    retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
+    hook: &mut H,
+) -> std::result::Result<SyncReport, SyncWithHookError<H::Error>> {
+    sync_inner(workspace, retrieve_db, hook, /* full = */ true)
+}
+
+fn sync_inner<H: IndexHook>(
+    workspace: &Workspace,
+    retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
+    hook: &mut H,
+    full: bool,
+) -> std::result::Result<SyncReport, SyncWithHookError<H::Error>> {
+    let known_mtimes = retrieve_db.file_mtimes().map_err(crate::Error::from)?;
+    let existing_ids: HashSet<i64> = retrieve_db
+        .document_ids()
+        .map_err(crate::Error::from)?
+        .into_iter()
+        .collect();
+
+    let candidates = collect_candidates(&workspace.root)?;
 
     let mut current_paths: HashSet<String> = HashSet::with_capacity(candidates.len());
     let mut current_ids: HashSet<i64> = HashSet::with_capacity(candidates.len());
     let mut upserted = 0usize;
 
-    // Phase 2: invoke hook per file.
     for path in &candidates {
         let path_str = path.to_string_lossy().into_owned();
         let doc_id = path_to_doc_id(path);
@@ -321,22 +283,19 @@ pub fn sync_workspace_with_hook<H: IndexHook>(
         current_ids.insert(doc_id);
 
         let disk_mtime = file_mtime_secs(path);
-        if let Some(&cached_mtime) = known_mtimes.get(&path_str)
+        if !full
+            && let Some(&cached_mtime) = known_mtimes.get(&path_str)
             && cached_mtime == disk_mtime
         {
             continue;
         }
 
-        let hooked = hook
-            .on_changed(path, disk_mtime)
+        hook.on_changed(path, disk_mtime)
             .map_err(SyncWithHookError::Hook)?;
 
-        let doc = match hooked {
-            Some(doc) => doc,
-            None => match build_default_document(path, doc_id) {
-                Some(doc) => doc,
-                None => continue,
-            },
+        let Ok(doc) = build_document_from_disk(path, doc_id) else {
+            // Unreadable file — leave the existing DB row untouched and move on.
+            continue;
         };
 
         retrieve_db
@@ -348,7 +307,7 @@ pub fn sync_workspace_with_hook<H: IndexHook>(
         upserted += 1;
     }
 
-    // Phase 3: removals — paths the DB knows about that are gone from disk.
+    // Removals: paths the DB knows about that are gone from disk.
     let mut removed_doc_ids: HashSet<i64> = HashSet::new();
     let mut removed = 0usize;
 
@@ -369,8 +328,7 @@ pub fn sync_workspace_with_hook<H: IndexHook>(
         }
     }
 
-    // Phase 3b: orphan documents — IDs in the DB with no corresponding file
-    // row. The hook has no path to receive, so we just drop the document.
+    // Orphan documents: IDs in the DB with no corresponding file row.
     for &id in &existing_ids {
         if current_ids.contains(&id) || removed_doc_ids.contains(&id) {
             continue;
@@ -381,10 +339,8 @@ pub fn sync_workspace_with_hook<H: IndexHook>(
         removed += 1;
     }
 
-    // Phase 4: hook gets a final chance before fts is rebuilt.
     hook.after_sweep().map_err(SyncWithHookError::Hook)?;
 
-    // Phase 5: rebuild FTS once if anything changed.
     if upserted > 0 || removed > 0 {
         retrieve_db.rebuild_fts().map_err(crate::Error::from)?;
     }
@@ -392,8 +348,8 @@ pub fn sync_workspace_with_hook<H: IndexHook>(
     Ok(SyncReport { upserted, removed })
 }
 
-/// Default no-op hook used internally by [`sync_workspace_incremental`].
-struct NoopHook;
+/// Default no-op hook used internally by the non-hook entry points.
+pub(crate) struct NoopHook;
 
 impl IndexHook for NoopHook {
     type Error = std::convert::Infallible;
@@ -402,12 +358,23 @@ impl IndexHook for NoopHook {
         &mut self,
         _path: &Path,
         _disk_mtime: i64,
-    ) -> std::result::Result<Option<Document>, Self::Error> {
-        Ok(None)
+    ) -> std::result::Result<(), Self::Error> {
+        Ok(())
     }
 
     fn on_removed(&mut self, _path: &str) -> std::result::Result<(), Self::Error> {
         Ok(())
+    }
+}
+
+/// Convert a `SyncWithHookError<Infallible>` to the crate's `Error` type.
+///
+/// Used by the legacy non-hook wrappers since `Infallible` cannot be
+/// constructed.
+pub(crate) fn unwrap_infallible(err: SyncWithHookError<std::convert::Infallible>) -> crate::Error {
+    match err {
+        SyncWithHookError::Workspace(e) => e,
+        SyncWithHookError::Hook(never) => match never {},
     }
 }
 
@@ -417,20 +384,14 @@ impl IndexHook for NoopHook {
 ///
 /// Returns `(upserted, removed)`.
 ///
-/// This is now a thin wrapper around [`sync_workspace_with_hook`] using a
-/// no-op hook. Behavior matches the prior bespoke implementation, with one
-/// minor cleanup: stale `files` rows for deleted paths are now removed
-/// (previously they were left behind, leaking entries over time).
+/// Thin wrapper around [`sync_workspace_with_hook`] using a no-op hook.
 pub fn sync_workspace_incremental(
     workspace: &Workspace,
     retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
 ) -> Result<(usize, usize)> {
     let mut hook = NoopHook;
     let report =
-        sync_workspace_with_hook(workspace, retrieve_db, &mut hook).map_err(|e| match e {
-            SyncWithHookError::Workspace(e) => e,
-            SyncWithHookError::Hook(never) => match never {},
-        })?;
+        sync_workspace_with_hook(workspace, retrieve_db, &mut hook).map_err(unwrap_infallible)?;
     Ok((report.upserted, report.removed))
 }
 
@@ -452,9 +413,9 @@ mod tests {
     }
 
     fn make_workspace() -> (TempDir, Workspace, Arc<dyn RetrieveStore + Send + Sync>) {
-        // Use a non-dotted prefix: `sync_workspace_with_hook` skips dotted
-        // directories at any depth (matching `sync_workspace_incremental`),
-        // which includes the workspace root.
+        // Use a non-dotted prefix: hook-aware sync skips dotted directories at
+        // any depth (matching `sync_workspace_incremental`), which includes the
+        // workspace root.
         let tmp = tempfile::Builder::new().prefix("ws-").tempdir().unwrap();
         let root = tmp.path().to_path_buf();
         fs::create_dir_all(root.join(".indexer-hook-test")).unwrap();
@@ -468,8 +429,6 @@ mod tests {
         changed: Vec<PathBuf>,
         removed: Vec<String>,
         after_sweep_count: Cell<usize>,
-        override_for: Option<PathBuf>,
-        override_body: String,
     }
 
     impl RecordingHook {
@@ -478,8 +437,6 @@ mod tests {
                 changed: Vec::new(),
                 removed: Vec::new(),
                 after_sweep_count: Cell::new(0),
-                override_for: None,
-                override_body: String::new(),
             }
         }
     }
@@ -491,18 +448,9 @@ mod tests {
             &mut self,
             path: &Path,
             _disk_mtime: i64,
-        ) -> std::result::Result<Option<Document>, Self::Error> {
+        ) -> std::result::Result<(), Self::Error> {
             self.changed.push(path.to_path_buf());
-            if self.override_for.as_deref() == Some(path) {
-                Ok(Some(Document {
-                    id: path_to_doc_id(path),
-                    body: self.override_body.clone(),
-                    path: path.to_string_lossy().into_owned(),
-                    chunks: None,
-                }))
-            } else {
-                Ok(None)
-            }
+            Ok(())
         }
 
         fn on_removed(&mut self, path: &str) -> std::result::Result<(), Self::Error> {
@@ -517,7 +465,7 @@ mod tests {
     }
 
     #[test]
-    fn hook_sees_changed_and_falls_back_to_default_indexing() {
+    fn hook_sees_changed_and_workspace_indexes_default() {
         let (tmp, ws, db) = make_workspace();
         let file = tmp.path().join("note.md");
         fs::write(&file, "hello world").unwrap();
@@ -531,42 +479,9 @@ mod tests {
         assert!(hook.removed.is_empty());
         assert_eq!(hook.after_sweep_count.get(), 1);
 
-        // Default indexing should have stored body via fts.
         assert_eq!(db.document_count().unwrap(), 1);
         let mtimes = db.file_mtimes().unwrap();
         assert!(mtimes.contains_key(file.to_string_lossy().as_ref()));
-    }
-
-    #[test]
-    fn hook_override_replaces_default_document() {
-        let (tmp, ws, db) = make_workspace();
-        let file = tmp.path().join("entry.md");
-        fs::write(&file, "raw on-disk body").unwrap();
-
-        let mut hook = RecordingHook::new();
-        hook.override_for = Some(file.clone());
-        hook.override_body = "synthetic body from hook".to_string();
-
-        let report = sync_workspace_with_hook(&ws, db.clone(), &mut hook).unwrap();
-        assert_eq!(report.upserted, 1);
-
-        // The override body should be searchable, not the raw file body.
-        let hits = db
-            .search_fts(&sapphire_retrieve::FtsQuery {
-                query: "synthetic",
-                path_prefix: None,
-                limit: 10,
-            })
-            .unwrap();
-        assert_eq!(hits.len(), 1);
-        let hits_raw = db
-            .search_fts(&sapphire_retrieve::FtsQuery {
-                query: "raw",
-                path_prefix: None,
-                limit: 10,
-            })
-            .unwrap();
-        assert!(hits_raw.is_empty());
     }
 
     #[test]
@@ -584,6 +499,28 @@ mod tests {
         assert_eq!(second.upserted, 0);
         assert!(hook2.changed.is_empty());
         assert_eq!(hook2.after_sweep_count.get(), 1);
+    }
+
+    #[test]
+    fn full_sync_with_hook_visits_every_file_regardless_of_mtime() {
+        let (tmp, ws, db) = make_workspace();
+        let file = tmp.path().join("stable.md");
+        fs::write(&file, "stable").unwrap();
+
+        let mut h1 = RecordingHook::new();
+        sync_workspace_with_hook(&ws, db.clone(), &mut h1).unwrap();
+        assert_eq!(h1.changed.len(), 1);
+
+        // Second incremental call: mtime unchanged → hook skipped.
+        let mut h2 = RecordingHook::new();
+        sync_workspace_with_hook(&ws, db.clone(), &mut h2).unwrap();
+        assert_eq!(h2.changed.len(), 0);
+
+        // Second full call: mtime unchanged but hook is still invoked.
+        let mut h3 = RecordingHook::new();
+        let r = sync_workspace_full_with_hook(&ws, db, &mut h3).unwrap();
+        assert_eq!(h3.changed.len(), 1);
+        assert_eq!(r.upserted, 1);
     }
 
     #[test]
@@ -630,7 +567,7 @@ mod tests {
             &mut self,
             _path: &Path,
             _disk_mtime: i64,
-        ) -> std::result::Result<Option<Document>, Self::Error> {
+        ) -> std::result::Result<(), Self::Error> {
             Err(Boom)
         }
         fn on_removed(&mut self, _path: &str) -> std::result::Result<(), Self::Error> {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,6 +1,11 @@
-use std::{collections::HashSet, path::Path, sync::Arc};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use sapphire_retrieve::{Chunker, Document, JsonlChunker, RetrieveStore, TomlChunker};
+use thiserror::Error;
 
 use crate::{error::Result, workspace::Workspace};
 
@@ -30,6 +35,61 @@ pub fn path_to_doc_id(path: &Path) -> i64 {
         h = h.wrapping_mul(PRIME);
     }
     h as i64
+}
+
+/// Build a [`Document`] for `path` using the extension-default chunking.
+///
+/// Returns `None` if the file cannot be read (mirrors the silent-skip behavior
+/// of the legacy [`sync_workspace_incremental`]).
+fn build_default_document(path: &Path, doc_id: i64) -> Option<Document> {
+    let raw = std::fs::read_to_string(path).ok()?;
+
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+
+    let is_jsonl = JSONL_EXTENSIONS.contains(&ext.as_str());
+    let is_toml = TOML_EXTENSIONS.contains(&ext.as_str());
+
+    let path_str = path.to_string_lossy().into_owned();
+
+    let doc = if is_jsonl || is_toml {
+        let file_name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let text_chunks = if is_jsonl {
+            JsonlChunker.chunk(&file_name, &raw)
+        } else {
+            TomlChunker.chunk(&file_name, &raw)
+        };
+        let body = text_chunks
+            .iter()
+            .map(|c| c.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let chunks: Vec<(usize, usize, String)> = text_chunks
+            .into_iter()
+            .map(|c| (c.line_start, c.line_end, c.text))
+            .collect();
+        Document {
+            id: doc_id,
+            body,
+            path: path_str,
+            chunks: Some(chunks),
+        }
+    } else {
+        Document {
+            id: doc_id,
+            body: raw,
+            path: path_str,
+            chunks: None,
+        }
+    };
+
+    Some(doc)
 }
 
 /// Recursively walk `workspace` and upsert all text files into `retrieve_db`.
@@ -87,45 +147,9 @@ pub fn sync_workspace(
             continue;
         }
 
-        let raw = match std::fs::read_to_string(path) {
-            Ok(s) => s,
-            Err(_) => continue,
-        };
-
         let doc_id = path_to_doc_id(path);
-
-        let doc = if is_jsonl || is_toml {
-            let file_name = path
-                .file_name()
-                .map(|n| n.to_string_lossy().into_owned())
-                .unwrap_or_default();
-            let text_chunks = if is_jsonl {
-                JsonlChunker.chunk(&file_name, &raw)
-            } else {
-                TomlChunker.chunk(&file_name, &raw)
-            };
-            let body = text_chunks
-                .iter()
-                .map(|c| c.text.as_str())
-                .collect::<Vec<_>>()
-                .join("\n\n");
-            let chunks: Vec<(usize, usize, String)> = text_chunks
-                .into_iter()
-                .map(|c| (c.line_start, c.line_end, c.text))
-                .collect();
-            Document {
-                id: doc_id,
-                body,
-                path: path.to_string_lossy().into_owned(),
-                chunks: Some(chunks),
-            }
-        } else {
-            Document {
-                id: doc_id,
-                body: raw,
-                path: path.to_string_lossy().into_owned(),
-                chunks: None,
-            }
+        let Some(doc) = build_default_document(path, doc_id) else {
+            continue;
         };
 
         retrieve_db.upsert_document(&doc)?;
@@ -149,28 +173,111 @@ pub fn sync_workspace(
     Ok((upserted, removed))
 }
 
-/// Walk the workspace and update only files whose mtime has changed since the
-/// last sync.  Also removes documents for files that no longer exist.
+// ── hook-driven incremental sync ──────────────────────────────────────────────
+
+/// Callback hook invoked during incremental sync.
 ///
-/// Returns `(upserted, removed)`.
+/// The workspace owns the walk, mtime read, default `Document` construction,
+/// and all writes to the retrieve DB. The hook gets to (a) override the
+/// `Document` construction for files it recognizes (e.g. parse frontmatter)
+/// and update its own caches, and (b) react to file removals.
 ///
-/// Unlike [`sync_workspace`], this function compares filesystem mtimes against
-/// the values stored in the retrieve DB and skips unchanged files, making it
-/// much cheaper for periodic background refreshes.
-pub fn sync_workspace_incremental(
+/// See [`sync_workspace_with_hook`].
+pub trait IndexHook {
+    /// Error type the hook can produce. Surfaces through [`SyncWithHookError::Hook`].
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Called when a file is new or its mtime changed, after the workspace
+    /// has decided the file is in scope (matching extension etc.).
+    ///
+    /// - `Ok(Some(doc))` → the workspace uses *this* `Document` for
+    ///   `upsert_document`, instead of building one from the raw file body.
+    ///   The hook is expected to have updated its own caches/tables already.
+    /// - `Ok(None)` → the workspace falls back to its default `Document`
+    ///   construction (read file body, chunk by extension, upsert). This is
+    ///   the path for files the hook doesn't recognize but still wants
+    ///   indexed for plain-text search.
+    fn on_changed(
+        &mut self,
+        path: &Path,
+        disk_mtime: i64,
+    ) -> std::result::Result<Option<Document>, Self::Error>;
+
+    /// Called for each path that was in retrieve DB but is gone from disk,
+    /// **before** the workspace removes its document/file row. The hook can
+    /// fetch IDs from its own DB and clean up here.
+    fn on_removed(&mut self, path: &str) -> std::result::Result<(), Self::Error>;
+
+    /// Called once after all changed/removed files have been processed but
+    /// before the final `rebuild_fts`. Suitable for batch validation
+    /// or for the caller to commit its own DB transaction.
+    fn after_sweep(&mut self) -> std::result::Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+/// Summary of a single [`sync_workspace_with_hook`] run.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct SyncReport {
+    pub upserted: usize,
+    pub removed: usize,
+}
+
+/// Error returned by [`sync_workspace_with_hook`].
+///
+/// Wraps either an error originating in the workspace itself or one returned
+/// by the [`IndexHook`], without forcing hook errors through the crate's
+/// [`Error`](crate::Error) enum.
+#[derive(Debug, Error)]
+pub enum SyncWithHookError<E: std::error::Error + Send + Sync + 'static> {
+    /// Error originating in workspace walking, file IO, or the retrieve DB.
+    #[error(transparent)]
+    Workspace(#[from] crate::Error),
+    /// Error returned by the [`IndexHook`].
+    #[error("index hook error: {0}")]
+    Hook(#[source] E),
+}
+
+/// Hook-driven incremental sync.
+///
+/// Walks `workspace.root` with the same extension set and `.`-hidden filter
+/// as [`sync_workspace_incremental`]. The hook is invoked per file but the
+/// workspace remains in charge of file enumeration, mtime tracking, and
+/// retrieve DB writes.
+///
+/// ## Phases
+///
+/// 1. **Collect candidates.** Walk the tree once and gather every in-scope
+///    file path into a vec before invoking the hook. This guarantees that
+///    file renames performed inside [`IndexHook::on_changed`] cannot perturb
+///    the in-flight walk.
+/// 2. **Per-file dispatch.** For each candidate, compare disk mtime against
+///    the cached value. If unchanged, skip. Otherwise call
+///    [`IndexHook::on_changed`]:
+///    - `Some(doc)` → workspace runs
+///      `upsert_file(path, disk_mtime) + upsert_document(&doc)`.
+///    - `None` → workspace builds a default `Document` from the file body
+///      and runs the same two upserts.
+/// 3. **Removals.** For each path in the retrieve DB that no longer appears
+///    on disk, call [`IndexHook::on_removed`] **before** `remove_file` /
+///    `remove_document`.
+/// 4. **`after_sweep`.** Called once, after all upserts and removals, before
+///    the final `rebuild_fts`.
+/// 5. **`rebuild_fts`** is run once if anything was upserted or removed.
+pub fn sync_workspace_with_hook<H: IndexHook>(
     workspace: &Workspace,
     retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
-) -> Result<(usize, usize)> {
-    let known_mtimes = retrieve_db.file_mtimes().unwrap_or_default();
+    hook: &mut H,
+) -> std::result::Result<SyncReport, SyncWithHookError<H::Error>> {
+    let known_mtimes = retrieve_db.file_mtimes().map_err(crate::Error::from)?;
     let existing_ids: HashSet<i64> = retrieve_db
         .document_ids()
-        .unwrap_or_default()
+        .map_err(crate::Error::from)?
         .into_iter()
         .collect();
 
-    let mut current_ids: HashSet<i64> = HashSet::new();
-    let mut upserted = 0;
-
+    // Phase 1: collect all in-scope candidate paths.
+    let mut candidates: Vec<PathBuf> = Vec::new();
     for entry in walkdir::WalkDir::new(&workspace.root)
         .follow_links(false)
         .into_iter()
@@ -182,12 +289,11 @@ pub fn sync_workspace_incremental(
             }
         })
     {
-        let entry = entry?;
+        let entry = entry.map_err(crate::Error::from)?;
         if !entry.file_type().is_file() {
             continue;
         }
         let path = entry.path();
-
         let ext = path
             .extension()
             .and_then(|e| e.to_str())
@@ -198,80 +304,360 @@ pub fn sync_workspace_incremental(
         let is_jsonl = JSONL_EXTENSIONS.contains(&ext.as_str());
         let is_toml = TOML_EXTENSIONS.contains(&ext.as_str());
 
-        if !is_markdown && !is_jsonl && !is_toml {
-            continue;
+        if is_markdown || is_jsonl || is_toml {
+            candidates.push(path.to_path_buf());
         }
+    }
 
+    let mut current_paths: HashSet<String> = HashSet::with_capacity(candidates.len());
+    let mut current_ids: HashSet<i64> = HashSet::with_capacity(candidates.len());
+    let mut upserted = 0usize;
+
+    // Phase 2: invoke hook per file.
+    for path in &candidates {
+        let path_str = path.to_string_lossy().into_owned();
         let doc_id = path_to_doc_id(path);
+        current_paths.insert(path_str.clone());
         current_ids.insert(doc_id);
 
-        // Check mtime — skip if unchanged.
-        let path_str = path.to_string_lossy();
         let disk_mtime = file_mtime_secs(path);
-        if let Some(&cached_mtime) = known_mtimes.get(path_str.as_ref())
+        if let Some(&cached_mtime) = known_mtimes.get(&path_str)
             && cached_mtime == disk_mtime
         {
             continue;
         }
 
-        let raw = match std::fs::read_to_string(path) {
-            Ok(s) => s,
-            Err(_) => continue,
+        let hooked = hook
+            .on_changed(path, disk_mtime)
+            .map_err(SyncWithHookError::Hook)?;
+
+        let doc = match hooked {
+            Some(doc) => doc,
+            None => match build_default_document(path, doc_id) {
+                Some(doc) => doc,
+                None => continue,
+            },
         };
 
-        let doc = if is_jsonl || is_toml {
-            let file_name = path
-                .file_name()
-                .map(|n| n.to_string_lossy().into_owned())
-                .unwrap_or_default();
-            let text_chunks = if is_jsonl {
-                JsonlChunker.chunk(&file_name, &raw)
-            } else {
-                TomlChunker.chunk(&file_name, &raw)
-            };
-            let body = text_chunks
-                .iter()
-                .map(|c| c.text.as_str())
-                .collect::<Vec<_>>()
-                .join("\n\n");
-            let chunks: Vec<(usize, usize, String)> = text_chunks
-                .into_iter()
-                .map(|c| (c.line_start, c.line_end, c.text))
-                .collect();
-            Document {
-                id: doc_id,
-                body,
-                path: path_str.into_owned(),
-                chunks: Some(chunks),
-            }
-        } else {
-            Document {
-                id: doc_id,
-                body: raw,
-                path: path_str.into_owned(),
-                chunks: None,
-            }
-        };
-
-        retrieve_db.upsert_file(&doc.path, disk_mtime)?;
-        retrieve_db.upsert_document(&doc)?;
+        retrieve_db
+            .upsert_file(&path_str, disk_mtime)
+            .map_err(crate::Error::from)?;
+        retrieve_db
+            .upsert_document(&doc)
+            .map_err(crate::Error::from)?;
         upserted += 1;
     }
 
-    if upserted > 0 {
-        retrieve_db.rebuild_fts()?;
-    }
+    // Phase 3: removals — paths the DB knows about that are gone from disk.
+    let mut removed_doc_ids: HashSet<i64> = HashSet::new();
+    let mut removed = 0usize;
 
-    let mut removed = 0;
-    for id in &existing_ids {
-        if !current_ids.contains(id) {
-            retrieve_db.remove_document(*id)?;
+    for path_str in known_mtimes.keys() {
+        if current_paths.contains(path_str) {
+            continue;
+        }
+        hook.on_removed(path_str).map_err(SyncWithHookError::Hook)?;
+        retrieve_db
+            .remove_file(path_str)
+            .map_err(crate::Error::from)?;
+        let doc_id = path_to_doc_id(Path::new(path_str));
+        if existing_ids.contains(&doc_id) && removed_doc_ids.insert(doc_id) {
+            retrieve_db
+                .remove_document(doc_id)
+                .map_err(crate::Error::from)?;
             removed += 1;
         }
     }
-    if removed > 0 {
-        retrieve_db.rebuild_fts()?;
+
+    // Phase 3b: orphan documents — IDs in the DB with no corresponding file
+    // row. The hook has no path to receive, so we just drop the document.
+    for &id in &existing_ids {
+        if current_ids.contains(&id) || removed_doc_ids.contains(&id) {
+            continue;
+        }
+        retrieve_db
+            .remove_document(id)
+            .map_err(crate::Error::from)?;
+        removed += 1;
     }
 
-    Ok((upserted, removed))
+    // Phase 4: hook gets a final chance before fts is rebuilt.
+    hook.after_sweep().map_err(SyncWithHookError::Hook)?;
+
+    // Phase 5: rebuild FTS once if anything changed.
+    if upserted > 0 || removed > 0 {
+        retrieve_db.rebuild_fts().map_err(crate::Error::from)?;
+    }
+
+    Ok(SyncReport { upserted, removed })
+}
+
+/// Default no-op hook used internally by [`sync_workspace_incremental`].
+struct NoopHook;
+
+impl IndexHook for NoopHook {
+    type Error = std::convert::Infallible;
+
+    fn on_changed(
+        &mut self,
+        _path: &Path,
+        _disk_mtime: i64,
+    ) -> std::result::Result<Option<Document>, Self::Error> {
+        Ok(None)
+    }
+
+    fn on_removed(&mut self, _path: &str) -> std::result::Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+/// Walk the workspace and update only files whose mtime has changed since the
+/// last sync. Also removes documents (and their file rows) for files that no
+/// longer exist.
+///
+/// Returns `(upserted, removed)`.
+///
+/// This is now a thin wrapper around [`sync_workspace_with_hook`] using a
+/// no-op hook. Behavior matches the prior bespoke implementation, with one
+/// minor cleanup: stale `files` rows for deleted paths are now removed
+/// (previously they were left behind, leaking entries over time).
+pub fn sync_workspace_incremental(
+    workspace: &Workspace,
+    retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
+) -> Result<(usize, usize)> {
+    let mut hook = NoopHook;
+    let report =
+        sync_workspace_with_hook(workspace, retrieve_db, &mut hook).map_err(|e| match e {
+            SyncWithHookError::Workspace(e) => e,
+            SyncWithHookError::Hook(never) => match never {},
+        })?;
+    Ok((report.upserted, report.removed))
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "sqlite-store"))]
+mod tests {
+    use std::{cell::Cell, fs};
+
+    use sapphire_retrieve::open_sqlite_fts;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::{AppContext, Workspace};
+
+    fn ctx() -> &'static AppContext {
+        static CTX: std::sync::OnceLock<AppContext> = std::sync::OnceLock::new();
+        CTX.get_or_init(|| AppContext::new("indexer-hook-test"))
+    }
+
+    fn make_workspace() -> (TempDir, Workspace, Arc<dyn RetrieveStore + Send + Sync>) {
+        // Use a non-dotted prefix: `sync_workspace_with_hook` skips dotted
+        // directories at any depth (matching `sync_workspace_incremental`),
+        // which includes the workspace root.
+        let tmp = tempfile::Builder::new().prefix("ws-").tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join(".indexer-hook-test")).unwrap();
+        let workspace = Workspace::from_root(ctx(), &root).unwrap();
+        let db_path = root.join(".indexer-hook-test").join("retrieve.sqlite");
+        let db = open_sqlite_fts(&db_path);
+        (tmp, workspace, db)
+    }
+
+    struct RecordingHook {
+        changed: Vec<PathBuf>,
+        removed: Vec<String>,
+        after_sweep_count: Cell<usize>,
+        override_for: Option<PathBuf>,
+        override_body: String,
+    }
+
+    impl RecordingHook {
+        fn new() -> Self {
+            Self {
+                changed: Vec::new(),
+                removed: Vec::new(),
+                after_sweep_count: Cell::new(0),
+                override_for: None,
+                override_body: String::new(),
+            }
+        }
+    }
+
+    impl IndexHook for RecordingHook {
+        type Error = std::convert::Infallible;
+
+        fn on_changed(
+            &mut self,
+            path: &Path,
+            _disk_mtime: i64,
+        ) -> std::result::Result<Option<Document>, Self::Error> {
+            self.changed.push(path.to_path_buf());
+            if self.override_for.as_deref() == Some(path) {
+                Ok(Some(Document {
+                    id: path_to_doc_id(path),
+                    body: self.override_body.clone(),
+                    path: path.to_string_lossy().into_owned(),
+                    chunks: None,
+                }))
+            } else {
+                Ok(None)
+            }
+        }
+
+        fn on_removed(&mut self, path: &str) -> std::result::Result<(), Self::Error> {
+            self.removed.push(path.to_owned());
+            Ok(())
+        }
+
+        fn after_sweep(&mut self) -> std::result::Result<(), Self::Error> {
+            self.after_sweep_count.set(self.after_sweep_count.get() + 1);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn hook_sees_changed_and_falls_back_to_default_indexing() {
+        let (tmp, ws, db) = make_workspace();
+        let file = tmp.path().join("note.md");
+        fs::write(&file, "hello world").unwrap();
+
+        let mut hook = RecordingHook::new();
+        let report = sync_workspace_with_hook(&ws, db.clone(), &mut hook).unwrap();
+
+        assert_eq!(report.upserted, 1);
+        assert_eq!(report.removed, 0);
+        assert_eq!(hook.changed, vec![file.clone()]);
+        assert!(hook.removed.is_empty());
+        assert_eq!(hook.after_sweep_count.get(), 1);
+
+        // Default indexing should have stored body via fts.
+        assert_eq!(db.document_count().unwrap(), 1);
+        let mtimes = db.file_mtimes().unwrap();
+        assert!(mtimes.contains_key(file.to_string_lossy().as_ref()));
+    }
+
+    #[test]
+    fn hook_override_replaces_default_document() {
+        let (tmp, ws, db) = make_workspace();
+        let file = tmp.path().join("entry.md");
+        fs::write(&file, "raw on-disk body").unwrap();
+
+        let mut hook = RecordingHook::new();
+        hook.override_for = Some(file.clone());
+        hook.override_body = "synthetic body from hook".to_string();
+
+        let report = sync_workspace_with_hook(&ws, db.clone(), &mut hook).unwrap();
+        assert_eq!(report.upserted, 1);
+
+        // The override body should be searchable, not the raw file body.
+        let hits = db
+            .search_fts(&sapphire_retrieve::FtsQuery {
+                query: "synthetic",
+                path_prefix: None,
+                limit: 10,
+            })
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        let hits_raw = db
+            .search_fts(&sapphire_retrieve::FtsQuery {
+                query: "raw",
+                path_prefix: None,
+                limit: 10,
+            })
+            .unwrap();
+        assert!(hits_raw.is_empty());
+    }
+
+    #[test]
+    fn unchanged_file_skips_hook_on_second_run() {
+        let (tmp, ws, db) = make_workspace();
+        let file = tmp.path().join("stable.md");
+        fs::write(&file, "stable").unwrap();
+
+        let mut hook = RecordingHook::new();
+        let first = sync_workspace_with_hook(&ws, db.clone(), &mut hook).unwrap();
+        assert_eq!(first.upserted, 1);
+
+        let mut hook2 = RecordingHook::new();
+        let second = sync_workspace_with_hook(&ws, db.clone(), &mut hook2).unwrap();
+        assert_eq!(second.upserted, 0);
+        assert!(hook2.changed.is_empty());
+        assert_eq!(hook2.after_sweep_count.get(), 1);
+    }
+
+    #[test]
+    fn removed_file_triggers_on_removed_before_db_delete() {
+        let (tmp, ws, db) = make_workspace();
+        let file = tmp.path().join("doomed.md");
+        fs::write(&file, "bye").unwrap();
+
+        let mut hook = RecordingHook::new();
+        sync_workspace_with_hook(&ws, db.clone(), &mut hook).unwrap();
+        let file_str = file.to_string_lossy().into_owned();
+        assert!(db.file_mtimes().unwrap().contains_key(&file_str));
+
+        fs::remove_file(&file).unwrap();
+        let mut hook2 = RecordingHook::new();
+        let report = sync_workspace_with_hook(&ws, db.clone(), &mut hook2).unwrap();
+
+        assert_eq!(report.removed, 1);
+        assert_eq!(hook2.removed, vec![file_str.clone()]);
+        assert!(!db.file_mtimes().unwrap().contains_key(&file_str));
+        assert_eq!(db.document_count().unwrap(), 0);
+    }
+
+    #[test]
+    fn after_sweep_runs_exactly_once_per_call() {
+        let (tmp, ws, db) = make_workspace();
+        fs::write(tmp.path().join("a.md"), "a").unwrap();
+        fs::write(tmp.path().join("b.md"), "b").unwrap();
+
+        let mut hook = RecordingHook::new();
+        sync_workspace_with_hook(&ws, db, &mut hook).unwrap();
+        assert_eq!(hook.after_sweep_count.get(), 1);
+        assert_eq!(hook.changed.len(), 2);
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("boom")]
+    struct Boom;
+
+    struct ErrorOnFirstChange;
+    impl IndexHook for ErrorOnFirstChange {
+        type Error = Boom;
+        fn on_changed(
+            &mut self,
+            _path: &Path,
+            _disk_mtime: i64,
+        ) -> std::result::Result<Option<Document>, Self::Error> {
+            Err(Boom)
+        }
+        fn on_removed(&mut self, _path: &str) -> std::result::Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn hook_error_is_propagated_as_hook_variant() {
+        let (tmp, ws, db) = make_workspace();
+        fs::write(tmp.path().join("a.md"), "a").unwrap();
+        let mut hook = ErrorOnFirstChange;
+        let err = sync_workspace_with_hook(&ws, db, &mut hook).unwrap_err();
+        assert!(matches!(err, SyncWithHookError::Hook(Boom)));
+    }
+
+    #[test]
+    fn wrapper_preserves_legacy_signature_and_counts() {
+        let (tmp, ws, db) = make_workspace();
+        fs::write(tmp.path().join("a.md"), "a").unwrap();
+        fs::write(tmp.path().join("b.md"), "b").unwrap();
+
+        let (up, rm) = sync_workspace_incremental(&ws, db.clone()).unwrap();
+        assert_eq!((up, rm), (2, 0));
+
+        fs::remove_file(tmp.path().join("a.md")).unwrap();
+        let (up2, rm2) = sync_workspace_incremental(&ws, db).unwrap();
+        assert_eq!((up2, rm2), (0, 1));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,10 @@ pub use config::{
     EmbeddingConfig, HybridConfig, RetrieveConfig, SyncBackendKind, SyncConfig, VectorDb,
 };
 pub use context::AppContext;
-pub use indexer::path_to_doc_id;
+pub use indexer::{
+    IndexHook, SyncReport, SyncWithHookError, path_to_doc_id, sync_workspace,
+    sync_workspace_incremental, sync_workspace_with_hook,
+};
 pub use workspace::Workspace;
 pub use workspace::{DEFAULT_WORKSPACE_MARKER, path_uuid};
 pub use workspace_state::{DbInfo, RetrieveParams, SearchMode, WorkspaceState};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use config::{
 pub use context::AppContext;
 pub use indexer::{
     IndexHook, SyncReport, SyncWithHookError, path_to_doc_id, sync_workspace,
-    sync_workspace_incremental, sync_workspace_with_hook,
+    sync_workspace_full_with_hook, sync_workspace_incremental, sync_workspace_with_hook,
 };
 pub use workspace::Workspace;
 pub use workspace::{DEFAULT_WORKSPACE_MARKER, path_uuid};

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -16,7 +16,11 @@ use tokio::sync::OnceCell;
 use crate::{
     config::{HybridConfig, RetrieveConfig, VectorDb},
     error::{Error, Result},
-    indexer::{path_to_doc_id, sync_workspace, sync_workspace_incremental},
+    indexer::{
+        IndexHook, SyncReport, SyncWithHookError, build_document_from_disk, file_mtime_secs,
+        is_indexable_path, path_to_doc_id, sync_workspace, sync_workspace_full_with_hook,
+        sync_workspace_incremental, sync_workspace_with_hook,
+    },
     workspace::Workspace,
 };
 
@@ -64,6 +68,13 @@ pub struct DbInfo {
     pub embedding_dim: u32,
     pub vector_count: u64,
     pub pending_count: u64,
+}
+
+/// Convert a `sapphire_retrieve::Error` to a `SyncWithHookError::Workspace`.
+fn map_retrieve_err<E: std::error::Error + Send + Sync + 'static>(
+    e: sapphire_retrieve::Error,
+) -> SyncWithHookError<E> {
+    SyncWithHookError::Workspace(Error::from(e))
 }
 
 // ── path resolution helpers ──────────────────────────────────────────────────
@@ -432,6 +443,89 @@ impl WorkspaceState {
         Ok(())
     }
 
+    // ── hook-aware single-file API ────────────────────────────────────────────
+
+    /// Like [`on_file_updated`](Self::on_file_updated) but invokes
+    /// `hook.on_changed` immediately before the retrieve DB is updated, so a
+    /// caller (e.g. sapphire-journal) can update its own per-file caches in
+    /// lockstep with the workspace.
+    ///
+    /// The hook does **not** see or modify the indexed [`Document`]; the
+    /// workspace always reads the file from disk and applies the default
+    /// chunking. Non-indexable extensions and external paths short-circuit
+    /// without invoking the hook.
+    pub fn on_file_updated_with_hook<H: IndexHook>(
+        &self,
+        path: &Path,
+        hook: &mut H,
+    ) -> std::result::Result<(), SyncWithHookError<H::Error>> {
+        let resolved = self
+            .resolve_path(path)
+            .map_err(SyncWithHookError::Workspace)?;
+        if !resolved.is_internal() {
+            return Ok(());
+        }
+        let abs = resolved.as_path();
+        if !is_indexable_path(abs) {
+            return Ok(());
+        }
+        let path_str = abs.to_string_lossy().into_owned();
+        let mtime = file_mtime_secs(abs);
+
+        hook.on_changed(abs, mtime)
+            .map_err(SyncWithHookError::Hook)?;
+
+        let doc_id = path_to_doc_id(abs);
+        let doc = build_document_from_disk(abs, doc_id)
+            .map_err(|e| SyncWithHookError::Workspace(Error::from(e)))?;
+
+        let db = self.retrieve_db();
+        db.upsert_file(&path_str, mtime).map_err(map_retrieve_err)?;
+        db.upsert_document(&doc).map_err(map_retrieve_err)?;
+        db.rebuild_fts().map_err(map_retrieve_err)?;
+
+        if let Some(sync) = &self.sync_backend {
+            sync.add_file(abs)
+                .map_err(|e| SyncWithHookError::Workspace(Error::from(e)))?;
+        }
+
+        Ok(())
+    }
+
+    /// Like [`on_file_deleted`](Self::on_file_deleted) but invokes
+    /// `hook.on_removed` immediately before the retrieve DB rows are deleted,
+    /// so the caller can clean up its own caches in lockstep.
+    pub fn on_file_deleted_with_hook<H: IndexHook>(
+        &self,
+        path: &Path,
+        hook: &mut H,
+    ) -> std::result::Result<(), SyncWithHookError<H::Error>> {
+        let resolved = self
+            .resolve_path(path)
+            .map_err(SyncWithHookError::Workspace)?;
+        if !resolved.is_internal() {
+            return Ok(());
+        }
+        let abs = resolved.as_path();
+        let path_str = abs.to_string_lossy().into_owned();
+        let doc_id = path_to_doc_id(abs);
+
+        hook.on_removed(&path_str)
+            .map_err(SyncWithHookError::Hook)?;
+
+        let db = self.retrieve_db();
+        db.remove_document(doc_id).map_err(map_retrieve_err)?;
+        db.remove_file(&path_str).map_err(map_retrieve_err)?;
+        db.rebuild_fts().map_err(map_retrieve_err)?;
+
+        if let Some(sync) = &self.sync_backend {
+            sync.remove_file(abs)
+                .map_err(|e| SyncWithHookError::Workspace(Error::from(e)))?;
+        }
+
+        Ok(())
+    }
+
     // ── path resolution ─────────��──────────────────────��───────────────────────
 
     /// Resolve `path` to an absolute path and classify it as internal or
@@ -655,6 +749,30 @@ impl WorkspaceState {
         sync_workspace_incremental(&self.workspace, self.retrieve_db())
     }
 
+    /// Hook-aware full sync (counterpart of [`sync`](Self::sync)).
+    ///
+    /// Re-indexes every file regardless of mtime and invokes `hook.on_changed`
+    /// / `hook.on_removed` / `hook.after_sweep` so the caller can update its
+    /// own per-file caches in lockstep with the workspace's retrieve DB.
+    pub fn sync_with_hook<H: IndexHook>(
+        &self,
+        hook: &mut H,
+    ) -> std::result::Result<SyncReport, SyncWithHookError<H::Error>> {
+        sync_workspace_full_with_hook(&self.workspace, self.retrieve_db(), hook)
+    }
+
+    /// Hook-aware incremental sync (counterpart of
+    /// [`sync_retrieve`](Self::sync_retrieve)).
+    ///
+    /// Skips files whose mtime matches the cached value; the hook is only
+    /// invoked for new / changed / removed paths.
+    pub fn sync_retrieve_with_hook<H: IndexHook>(
+        &self,
+        hook: &mut H,
+    ) -> std::result::Result<SyncReport, SyncWithHookError<H::Error>> {
+        sync_workspace_with_hook(&self.workspace, self.retrieve_db(), hook)
+    }
+
     /// Run a full git sync cycle (commit → pull → push), if a sync backend is
     /// configured.  Does **not** update the retrieve cache.
     pub fn sync_git(&self) -> Result<()> {
@@ -859,6 +977,158 @@ impl WorkspaceState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "sqlite-store")]
+    mod hook {
+        use super::super::*;
+        use crate::AppContext;
+        use std::cell::Cell;
+        use std::fs;
+        use std::path::PathBuf;
+
+        fn ctx() -> &'static AppContext {
+            static CTX: std::sync::OnceLock<AppContext> = std::sync::OnceLock::new();
+            CTX.get_or_init(|| AppContext::new("ws-state-hook-test"))
+        }
+
+        fn make_state() -> (tempfile::TempDir, WorkspaceState) {
+            // Avoid dotted prefix: the workspace walker filters dotted dirs at
+            // any depth including the root.
+            let tmp = tempfile::Builder::new().prefix("ws-").tempdir().unwrap();
+            // Each tempdir gets a fresh cache root: setting `set_cache_dir` is
+            // first-writer-wins, so we accept whatever the first test puts
+            // there. Use a process-wide tmp subdir as the shared cache.
+            ctx().set_cache_dir(std::env::temp_dir().join("ws-state-hook-cache"));
+            fs::create_dir_all(tmp.path().join(".ws-state-hook-test")).unwrap();
+            let ws = Workspace::from_root(ctx(), tmp.path()).unwrap();
+            let state = WorkspaceState::open(ws).unwrap();
+            (tmp, state)
+        }
+
+        struct RecordingHook {
+            changed: Vec<PathBuf>,
+            removed: Vec<String>,
+            after_sweep_count: Cell<usize>,
+        }
+        impl RecordingHook {
+            fn new() -> Self {
+                Self {
+                    changed: Vec::new(),
+                    removed: Vec::new(),
+                    after_sweep_count: Cell::new(0),
+                }
+            }
+        }
+        impl IndexHook for RecordingHook {
+            type Error = std::convert::Infallible;
+            fn on_changed(&mut self, p: &Path, _m: i64) -> std::result::Result<(), Self::Error> {
+                self.changed.push(p.to_path_buf());
+                Ok(())
+            }
+            fn on_removed(&mut self, p: &str) -> std::result::Result<(), Self::Error> {
+                self.removed.push(p.to_owned());
+                Ok(())
+            }
+            fn after_sweep(&mut self) -> std::result::Result<(), Self::Error> {
+                self.after_sweep_count.set(self.after_sweep_count.get() + 1);
+                Ok(())
+            }
+        }
+
+        #[test]
+        fn sync_retrieve_with_hook_invokes_hook_per_changed_file() {
+            let (tmp, state) = make_state();
+            fs::write(tmp.path().join("a.md"), "a").unwrap();
+            fs::write(tmp.path().join("b.md"), "b").unwrap();
+
+            let mut hook = RecordingHook::new();
+            let report = state.sync_retrieve_with_hook(&mut hook).unwrap();
+
+            assert_eq!(report.upserted, 2);
+            assert_eq!(report.removed, 0);
+            assert_eq!(hook.changed.len(), 2);
+            assert_eq!(hook.after_sweep_count.get(), 1);
+        }
+
+        #[test]
+        fn sync_retrieve_with_hook_skips_unchanged_files() {
+            let (tmp, state) = make_state();
+            fs::write(tmp.path().join("stable.md"), "x").unwrap();
+
+            let mut h1 = RecordingHook::new();
+            state.sync_retrieve_with_hook(&mut h1).unwrap();
+            assert_eq!(h1.changed.len(), 1);
+
+            let mut h2 = RecordingHook::new();
+            let r = state.sync_retrieve_with_hook(&mut h2).unwrap();
+            assert_eq!(h2.changed.len(), 0);
+            assert_eq!(r.upserted, 0);
+        }
+
+        #[test]
+        fn sync_with_hook_runs_full_re_index() {
+            let (tmp, state) = make_state();
+            fs::write(tmp.path().join("stable.md"), "x").unwrap();
+
+            // Prime the incremental cache so mtimes are recorded.
+            let mut h1 = RecordingHook::new();
+            state.sync_retrieve_with_hook(&mut h1).unwrap();
+
+            // Full sync must invoke the hook even though nothing changed.
+            let mut h2 = RecordingHook::new();
+            let r = state.sync_with_hook(&mut h2).unwrap();
+            assert_eq!(h2.changed.len(), 1);
+            assert_eq!(r.upserted, 1);
+        }
+
+        #[test]
+        fn on_file_updated_with_hook_indexes_and_fires_hook() {
+            let (tmp, state) = make_state();
+            let file = tmp.path().join("note.md");
+            fs::write(&file, "body").unwrap();
+
+            let mut hook = RecordingHook::new();
+            state.on_file_updated_with_hook(&file, &mut hook).unwrap();
+
+            assert_eq!(hook.changed, vec![file.canonicalize().unwrap()]);
+            assert_eq!(state.retrieve_db().document_count().unwrap(), 1);
+        }
+
+        #[test]
+        fn on_file_updated_with_hook_skips_non_indexable_extension() {
+            let (tmp, state) = make_state();
+            let file = tmp.path().join("blob.bin");
+            fs::write(&file, "data").unwrap();
+
+            let mut hook = RecordingHook::new();
+            state.on_file_updated_with_hook(&file, &mut hook).unwrap();
+
+            assert!(hook.changed.is_empty());
+            assert_eq!(state.retrieve_db().document_count().unwrap(), 0);
+        }
+
+        #[test]
+        fn on_file_deleted_with_hook_calls_hook_then_removes() {
+            let (tmp, state) = make_state();
+            let file = tmp.path().join("doomed.md");
+            fs::write(&file, "bye").unwrap();
+            state
+                .on_file_updated_with_hook(&file, &mut RecordingHook::new())
+                .unwrap();
+            assert_eq!(state.retrieve_db().document_count().unwrap(), 1);
+
+            let mut hook = RecordingHook::new();
+            state.on_file_deleted_with_hook(&file, &mut hook).unwrap();
+
+            assert_eq!(hook.removed.len(), 1);
+            assert!(
+                hook.removed[0].ends_with("doomed.md"),
+                "got {:?}",
+                hook.removed[0]
+            );
+            assert_eq!(state.retrieve_db().document_count().unwrap(), 0);
+        }
+    }
 
     /// Regression for #48: `canonicalize_or_parent` previously returned a path
     /// with a trailing separator for not-yet-existing files, which caused


### PR DESCRIPTION
Closes #68.

## Summary

- 新規 `IndexHook` trait + `sync_workspace_with_hook` / `sync_workspace_full_with_hook` で、外部呼び出し側 (sapphire-journal 等) が workspace の walk + mtime tracking + retrieve DB 書き込みに乗っかって自前 DB を同タイミング更新できる経路を提供
- Hook は **side channel** に徹する設計: `on_changed -> Result<(), Self::Error>` のみで、indexed Document の構築は workspace 側が常に実施。アプリ側でデータ前処理しないという要件に沿う
- `WorkspaceState` に hook-aware なエントリポイントを追加: `sync_with_hook` / `sync_retrieve_with_hook` / `on_file_updated_with_hook` / `on_file_deleted_with_hook`
- 後方互換: 既存 `sync_workspace_incremental` 等は `NoopHook` 経由の薄いラッパに。stale `files` 行が delete 時に残るバグも併せて修正（副次的）

## Design notes

- 走査と hook 呼び出しを2フェーズに分離（候補 path 全部集めてから hook ループ）し、hook 内のファイル rename 等を安全に許容
- `on_removed` 呼び出し順: `hook.on_removed` → `remove_file` → `remove_document`
- `after_sweep` は `rebuild_fts` の直前に1回だけ呼び、hook 側の最終トランザクション commit 等に使える
- Hook エラーは `SyncWithHookError::Hook(E)` でそのまま貫通させ、crate の `Error` enum を汚さない

将来的に「アプリ管理対象フラグの永続化」を追加検討する派生案は #70 として分離。

## Test plan

- [x] `cargo test --lib` — 15/15 pass (indexer hook tests 7 + WorkspaceState hook tests 6 + 既存 2)
- [x] `cargo clippy --lib --all-features -- -D warnings` — clean
- [x] `cargo fmt --all` 反映済
- [ ] sapphire-journal 側で `sync_retrieve_with_hook` を呼ぶ実装に差し替える後続イシューは別途

🤖 Generated with [Claude Code](https://claude.com/claude-code)