### PR TITLE
refactor: extract mtime change-detection into sapphire-track crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/sapphire-sync",
     "crates/sapphire-retrieve",
+    "crates/sapphire-track",
     "crates/sapphire-workspace-cli",
 ]
 resolver = "3"
@@ -54,6 +55,7 @@ git-sync        = ["sapphire-sync/git"]
 [dependencies]
 sapphire-retrieve = { version = "0.12.1", path = "crates/sapphire-retrieve", default-features = false }
 sapphire-sync     = { version = "0.12.1", path = "crates/sapphire-sync", default-features = false }
+sapphire-track    = { version = "0.12.1", path = "crates/sapphire-track" }
 thiserror.workspace = true
 serde.workspace = true
 toml.workspace = true

--- a/crates/sapphire-retrieve/src/db.rs
+++ b/crates/sapphire-retrieve/src/db.rs
@@ -1,8 +1,8 @@
 //! Unified retrieve database: FTS5 + vector search.
 //!
 //! [`RetrieveDb`] is the main entry point.  It manages one of the available
-//! storage backends and exposes a unified API for file tracking, document
-//! management, full-text search, and vector search.
+//! storage backends and exposes a unified API for document management,
+//! full-text search, and vector search.
 
 use std::{
     collections::HashMap,
@@ -39,7 +39,6 @@ struct InMemoryStore {
 
 #[derive(Default)]
 struct InMemoryState {
-    files: HashMap<String, i64>,
     documents: HashMap<i64, Document>,
 }
 
@@ -52,28 +51,6 @@ impl InMemoryStore {
 }
 
 impl RetrieveStore for InMemoryStore {
-    fn file_mtimes(&self) -> Result<HashMap<String, i64>> {
-        Ok(self.state.lock().unwrap().files.clone())
-    }
-
-    fn upsert_file(&self, path: &str, mtime: i64) -> Result<()> {
-        self.state
-            .lock()
-            .unwrap()
-            .files
-            .insert(path.to_owned(), mtime);
-        Ok(())
-    }
-
-    fn remove_file(&self, path: &str) -> Result<()> {
-        self.state.lock().unwrap().files.remove(path);
-        Ok(())
-    }
-
-    fn file_count(&self) -> Result<u64> {
-        Ok(self.state.lock().unwrap().files.len() as u64)
-    }
-
     fn upsert_document(&self, doc: &Document) -> Result<()> {
         self.state
             .lock()
@@ -296,24 +273,6 @@ impl RetrieveDb {
 
     pub fn document_count(&self) -> Result<u64> {
         self.store().document_count()
-    }
-
-    // ── file tracking ─────────────────────────────────────────────────────────
-
-    pub fn file_mtimes(&self) -> Result<HashMap<String, i64>> {
-        self.store().file_mtimes()
-    }
-
-    pub fn upsert_file(&self, path: &str, mtime: i64) -> Result<()> {
-        self.store().upsert_file(path, mtime)
-    }
-
-    pub fn remove_file(&self, path: &str) -> Result<()> {
-        self.store().remove_file(path)
-    }
-
-    pub fn file_count(&self) -> Result<u64> {
-        self.store().file_count()
     }
 }
 

--- a/crates/sapphire-retrieve/src/lancedb_store.rs
+++ b/crates/sapphire-retrieve/src/lancedb_store.rs
@@ -8,7 +8,6 @@
 //!
 //! | table           | columns                                                                                          |
 //! |-----------------|--------------------------------------------------------------------------------------------------|
-//! | `files`         | `path Utf8, mtime Int64`                                                                         |
 //! | `documents`     | `id Int64, path Utf8`                                                                            |
 //! | `chunks_meta`   | `doc_id Int64, line_start Int32, line_end Int32, text Utf8, doc_path Utf8`                       |
 //! | `chunk_vectors` | `doc_id Int64, line_start Int32, line_end Int32, doc_path Utf8, text Utf8, embedding FixedSizeList<Float32>` |
@@ -61,19 +60,11 @@ pub fn data_dir(root: &Path) -> PathBuf {
 
 // ── table names ───────────────────────────────────────────────────────────────
 
-const TBL_FILES: &str = "files";
 const TBL_DOCUMENTS: &str = "documents";
 const TBL_CHUNKS_META: &str = "chunks_meta";
 const TBL_CHUNK_VECTORS: &str = "chunk_vectors";
 
 // ── Arrow schemas ─────────────────────────────────────────────────────────────
-
-fn files_schema() -> Arc<Schema> {
-    Arc::new(Schema::new(vec![
-        Field::new("path", DataType::Utf8, false),
-        Field::new("mtime", DataType::Int64, false),
-    ]))
-}
 
 fn documents_schema() -> Arc<Schema> {
     Arc::new(Schema::new(vec![
@@ -142,7 +133,6 @@ fn make_embedding_array(embeddings: &[Vec<f32>], dim: i32) -> Result<FixedSizeLi
 // ── async inner ───────────────────────────────────────────────────────────────
 
 struct LanceFullStore {
-    files: lancedb::Table,
     documents: lancedb::Table,
     chunks_meta: lancedb::Table,
     chunk_vectors: lancedb::Table,
@@ -157,72 +147,17 @@ impl LanceFullStore {
             .await?;
         let dim = embedding_dim as i32;
 
-        let files = open_or_create(&db, TBL_FILES, files_schema()).await?;
         let documents = open_or_create(&db, TBL_DOCUMENTS, documents_schema()).await?;
         let chunks_meta = open_or_create(&db, TBL_CHUNKS_META, chunks_meta_schema()).await?;
         let chunk_vectors =
             open_or_create(&db, TBL_CHUNK_VECTORS, chunk_vectors_schema(dim)).await?;
 
         Ok(Self {
-            files,
             documents,
             chunks_meta,
             chunk_vectors,
             dim,
         })
-    }
-
-    // ── file tracking ─────────────────────────────────────────────────────────
-
-    async fn file_mtimes(&self) -> Result<HashMap<String, i64>> {
-        let batches: Vec<RecordBatch> = self.files.query().execute().await?.try_collect().await?;
-
-        let mut map = HashMap::new();
-        for batch in &batches {
-            let paths = batch
-                .column_by_name("path")
-                .and_then(|c| c.as_any().downcast_ref::<StringArray>());
-            let mtimes = batch
-                .column_by_name("mtime")
-                .and_then(|c| c.as_any().downcast_ref::<Int64Array>());
-            if let (Some(ps), Some(ms)) = (paths, mtimes) {
-                for i in 0..batch.num_rows() {
-                    map.insert(ps.value(i).to_owned(), ms.value(i));
-                }
-            }
-        }
-        Ok(map)
-    }
-
-    async fn upsert_file(&self, path: &str, mtime: i64) -> Result<()> {
-        let schema = files_schema();
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(StringArray::from(vec![path])),
-                Arc::new(Int64Array::from(vec![mtime])),
-            ],
-        )
-        .map_err(|e| Error::Embed(e.to_string()))?;
-
-        let mut merge = self.files.merge_insert(&["path"]);
-        merge
-            .when_matched_update_all(None)
-            .when_not_matched_insert_all();
-        merge
-            .execute(Box::new(RecordBatchIterator::new(vec![Ok(batch)], schema)))
-            .await?;
-        Ok(())
-    }
-
-    async fn remove_file(&self, path: &str) -> Result<()> {
-        let safe = escape_sql_string(path);
-        self.files.delete(&format!("path = '{safe}'")).await?;
-        Ok(())
-    }
-
-    async fn file_count(&self) -> Result<u64> {
-        Ok(self.files.count_rows(None).await? as u64)
     }
 
     // ── document management ───────────────────────────────────────────────────
@@ -682,24 +617,6 @@ impl LanceDbBackend {
         Self::block_on_with(&self.rt, f)
     }
 
-    // ── file tracking ─────────────────────────────────────────────────────────
-
-    pub fn file_mtimes(&self) -> Result<HashMap<String, i64>> {
-        self.block_on(self.inner.file_mtimes())
-    }
-
-    pub fn upsert_file(&self, path: &str, mtime: i64) -> Result<()> {
-        self.block_on(self.inner.upsert_file(path, mtime))
-    }
-
-    pub fn remove_file(&self, path: &str) -> Result<()> {
-        self.block_on(self.inner.remove_file(path))
-    }
-
-    pub fn file_count(&self) -> Result<u64> {
-        self.block_on(self.inner.file_count())
-    }
-
     // ── document management ───────────────────────────────────────────────────
 
     pub fn upsert_document(&self, doc: &Document) -> Result<()> {
@@ -774,22 +691,6 @@ impl LanceDbBackend {
 // ── RetrieveStore impl ────────────────────────────────────────────────────────
 
 impl RetrieveStore for LanceDbBackend {
-    fn file_mtimes(&self) -> Result<HashMap<String, i64>> {
-        self.file_mtimes()
-    }
-
-    fn upsert_file(&self, path: &str, mtime: i64) -> Result<()> {
-        self.upsert_file(path, mtime)
-    }
-
-    fn remove_file(&self, path: &str) -> Result<()> {
-        self.remove_file(path)
-    }
-
-    fn file_count(&self) -> Result<u64> {
-        self.file_count()
-    }
-
     fn upsert_document(&self, doc: &Document) -> Result<()> {
         self.upsert_document(doc)
     }

--- a/crates/sapphire-retrieve/src/retrieve_store.rs
+++ b/crates/sapphire-retrieve/src/retrieve_store.rs
@@ -7,7 +7,6 @@
 //! All methods are **synchronous**.  Async backends must wrap their async
 //! operations inside a dedicated Tokio runtime.
 
-use std::collections::HashMap;
 use std::path::Path;
 
 use crate::{embed::Embedder, error::Result, vector_store::VecInfo};
@@ -215,13 +214,6 @@ pub struct FileSearchResult {
 /// - [`LanceDbBackend`](crate::lancedb_store::LanceDbBackend) — LanceDB backend
 ///   (requires the `lancedb-store` feature).
 pub trait RetrieveStore: Send + Sync {
-    // ── file tracking ──────────────────────────────────────────────────────────
-
-    fn file_mtimes(&self) -> Result<HashMap<String, i64>>;
-    fn upsert_file(&self, path: &str, mtime: i64) -> Result<()>;
-    fn remove_file(&self, path: &str) -> Result<()>;
-    fn file_count(&self) -> Result<u64>;
-
     // ── document management ────────────────────────────────────────────────────
 
     fn upsert_document(&self, doc: &Document) -> Result<()>;

--- a/crates/sapphire-retrieve/src/sqlite_store.rs
+++ b/crates/sapphire-retrieve/src/sqlite_store.rs
@@ -43,14 +43,11 @@ use crate::{
 /// - 3: replace `chunk_index` with `line` + `column` (source positions)
 /// - 4: chunk-level FTS (`chunks_fts`), `line_start`/`line_end`, drop
 ///   `documents.body` and `documents_fts`
-pub const SCHEMA_VERSION: i32 = 4;
+/// - 5: drop the `files` table; mtime-based file-change tracking moved to the
+///   `sapphire-track` crate
+pub const SCHEMA_VERSION: i32 = 5;
 
 const SCHEMA: &str = "
-CREATE TABLE IF NOT EXISTS files (
-    path       TEXT    PRIMARY KEY,
-    file_mtime INTEGER NOT NULL
-);
-
 CREATE TABLE IF NOT EXISTS documents (
     id    INTEGER PRIMARY KEY,
     path  TEXT    NOT NULL DEFAULT ''
@@ -123,41 +120,6 @@ impl SqliteStore {
 }
 
 impl RetrieveStore for SqliteStore {
-    // ── file tracking ──────────────────────────────────────────────────────────
-
-    fn file_mtimes(&self) -> Result<HashMap<String, i64>> {
-        let conn = self.open_conn()?;
-        let mut stmt = conn.prepare("SELECT path, file_mtime FROM files")?;
-        let result = stmt
-            .query_map([], |row| {
-                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
-            })?
-            .collect::<rusqlite::Result<HashMap<_, _>>>()?;
-        Ok(result)
-    }
-
-    fn upsert_file(&self, path: &str, mtime: i64) -> Result<()> {
-        let conn = self.open_conn()?;
-        conn.execute(
-            "INSERT OR REPLACE INTO files (path, file_mtime) VALUES (?1, ?2)",
-            params![path, mtime],
-        )?;
-        Ok(())
-    }
-
-    fn remove_file(&self, path: &str) -> Result<()> {
-        let conn = self.open_conn()?;
-        conn.execute("DELETE FROM files WHERE path = ?1", [path])?;
-        Ok(())
-    }
-
-    fn file_count(&self) -> Result<u64> {
-        let conn = self.open_conn()?;
-        let count: u64 =
-            conn.query_row("SELECT COUNT(*) FROM files", [], |row| row.get::<_, i64>(0))? as u64;
-        Ok(count)
-    }
-
     // ── document management ────────────────────────────────────────────────────
 
     fn upsert_document(&self, doc: &Document) -> Result<()> {

--- a/crates/sapphire-track/Cargo.toml
+++ b/crates/sapphire-track/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "sapphire-track"
+version.workspace = true
+edition.workspace = true
+description = "File-type-agnostic mtime-based file-change detection"
+license.workspace = true
+repository.workspace = true
+keywords = ["filesystem", "mtime", "change-detection", "cache"]
+categories = ["filesystem"]
+
+[dependencies]
+redb = "2"
+thiserror.workspace = true
+walkdir = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/sapphire-track/src/error.rs
+++ b/crates/sapphire-track/src/error.rs
@@ -1,0 +1,25 @@
+use thiserror::Error;
+
+/// Errors produced by the [`sapphire-track`](crate) crate.
+///
+/// The redb sub-errors are kept as distinct variants so that `?` works
+/// directly on every storage operation without an intermediate conversion.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("directory walk error: {0}")]
+    Walk(#[from] walkdir::Error),
+    #[error("redb database error: {0}")]
+    RedbDatabase(#[from] redb::DatabaseError),
+    #[error("redb transaction error: {0}")]
+    RedbTransaction(#[from] redb::TransactionError),
+    #[error("redb table error: {0}")]
+    RedbTable(#[from] redb::TableError),
+    #[error("redb storage error: {0}")]
+    RedbStorage(#[from] redb::StorageError),
+    #[error("redb commit error: {0}")]
+    RedbCommit(#[from] redb::CommitError),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/sapphire-track/src/lib.rs
+++ b/crates/sapphire-track/src/lib.rs
@@ -1,0 +1,282 @@
+//! File-type-agnostic mtime-based file-change detection.
+//!
+//! `sapphire-track` owns the "what files changed since last time" concern,
+//! independent of *why* a caller cares about those files. It persists a
+//! `path -> mtime` snapshot and diffs the current filesystem state against it.
+//!
+//! The crate deliberately knows nothing about file types: the caller decides
+//! which paths to track by supplying an `accept` predicate to [`scan`] (or by
+//! feeding [`Observed`] entries directly to [`diff`]). This keeps retrieval
+//! concerns (handled by `sapphire-retrieve`) separate from change detection —
+//! an application can track updates to files that are *not* retrievable (e.g.
+//! audio assets) without involving the retrieve index at all.
+//!
+//! ## Backends
+//!
+//! - [`open_redb`] — persistent, pure-Rust [redb] store (the default).
+//! - [`open_in_memory`] — ephemeral [`InMemoryTrackStore`] for tests and
+//!   no-persistence builds.
+//!
+//! The store is treated as a rebuildable cache: if the on-disk format becomes
+//! incompatible the file is simply recreated (callers version the filename).
+//!
+//! [redb]: https://docs.rs/redb
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+};
+
+mod error;
+mod redb_store;
+
+pub use error::{Error, Result};
+pub use redb_store::RedbTrackStore;
+
+/// One observed path plus its current mtime (seconds since the UNIX epoch).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Observed {
+    pub path: PathBuf,
+    pub mtime: i64,
+}
+
+/// The result of diffing the current filesystem state against a stored
+/// snapshot.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Changes {
+    /// Observed now, absent from the stored snapshot.
+    pub added: Vec<PathBuf>,
+    /// Present in the snapshot but with a different mtime.
+    pub modified: Vec<PathBuf>,
+    /// Present in the snapshot but not observed now.
+    pub removed: Vec<PathBuf>,
+}
+
+impl Changes {
+    /// `true` when nothing was added, modified, or removed.
+    pub fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.modified.is_empty() && self.removed.is_empty()
+    }
+
+    /// The set of paths a caller must re-process: `added` followed by
+    /// `modified`.
+    pub fn upserted(&self) -> impl Iterator<Item = &Path> {
+        self.added
+            .iter()
+            .chain(self.modified.iter())
+            .map(PathBuf::as_path)
+    }
+}
+
+/// Persistent `path -> mtime` store.
+///
+/// All methods are synchronous, mirroring the style of
+/// `sapphire_retrieve::RetrieveStore`. Paths are stored as their string
+/// representation; the caller is responsible for passing consistent
+/// (e.g. canonicalized) paths.
+pub trait TrackStore: Send + Sync {
+    /// Return the full `path -> mtime` snapshot.
+    fn mtimes(&self) -> Result<HashMap<String, i64>>;
+
+    /// Insert or update the mtime for `path`.
+    fn upsert(&self, path: &str, mtime: i64) -> Result<()>;
+
+    /// Remove the entry for `path` (no-op if absent).
+    fn remove(&self, path: &str) -> Result<()>;
+
+    /// Number of tracked paths.
+    fn count(&self) -> Result<u64>;
+
+    /// Insert or update many entries. Backends override this to commit the
+    /// whole batch in a single transaction.
+    fn upsert_many(&self, entries: &[(String, i64)]) -> Result<()> {
+        for (path, mtime) in entries {
+            self.upsert(path, *mtime)?;
+        }
+        Ok(())
+    }
+}
+
+/// Diff `observed` (the current filesystem state) against `stored` (the
+/// previous snapshot). Pure: performs no I/O.
+///
+/// Caller-supplied filtering is assumed to already be applied to `observed`.
+pub fn diff(stored: &HashMap<String, i64>, observed: &[Observed]) -> Changes {
+    let mut changes = Changes::default();
+    let mut seen: HashSet<String> = HashSet::with_capacity(observed.len());
+
+    for obs in observed {
+        let key = obs.path.to_string_lossy().into_owned();
+        match stored.get(&key) {
+            None => changes.added.push(obs.path.clone()),
+            Some(&prev) if prev != obs.mtime => changes.modified.push(obs.path.clone()),
+            Some(_) => {}
+        }
+        seen.insert(key);
+    }
+
+    for path in stored.keys() {
+        if !seen.contains(path) {
+            changes.removed.push(PathBuf::from(path));
+        }
+    }
+
+    changes
+}
+
+/// Read the stored snapshot from `store` and diff `observed` against it.
+///
+/// Does **not** mutate the store — the caller commits new mtimes (via
+/// [`TrackStore::upsert_many`]) only after successfully processing the
+/// changes, so an interrupted run re-detects the work rather than dropping it.
+pub fn detect_changes(store: &dyn TrackStore, observed: &[Observed]) -> Result<Changes> {
+    let stored = store.mtimes()?;
+    Ok(diff(&stored, observed))
+}
+
+/// Return the mtime of `path` as seconds since the UNIX epoch, or 0 on error.
+pub fn mtime_secs(path: &Path) -> i64 {
+    path.metadata()
+        .and_then(|m| m.modified())
+        .map(|t| {
+            t.duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as i64
+        })
+        .unwrap_or(0)
+}
+
+/// Walk `root` recursively and return an [`Observed`] entry for every file for
+/// which `accept(path)` is `true`.
+///
+/// Directories whose name starts with `.` are skipped at any depth (matching
+/// the workspace indexer's hidden-directory filter). Symlinks are not
+/// followed.
+pub fn scan<F: Fn(&Path) -> bool>(root: &Path, accept: F) -> Result<Vec<Observed>> {
+    let mut out = Vec::new();
+    for entry in walkdir::WalkDir::new(root)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| {
+            if e.file_type().is_dir() {
+                !e.file_name().to_string_lossy().starts_with('.')
+            } else {
+                true
+            }
+        })
+    {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if accept(path) {
+            out.push(Observed {
+                path: path.to_path_buf(),
+                mtime: mtime_secs(path),
+            });
+        }
+    }
+    Ok(out)
+}
+
+/// Open (or create) a persistent redb-backed [`TrackStore`] at `path`.
+pub fn open_redb(path: &Path) -> Result<RedbTrackStore> {
+    RedbTrackStore::open(path)
+}
+
+/// Create an ephemeral in-memory [`TrackStore`].
+pub fn open_in_memory() -> InMemoryTrackStore {
+    InMemoryTrackStore::default()
+}
+
+/// In-memory [`TrackStore`] backed by a `Mutex<HashMap>`. Used for tests and
+/// no-persistence builds.
+#[derive(Default)]
+pub struct InMemoryTrackStore {
+    inner: std::sync::Mutex<HashMap<String, i64>>,
+}
+
+impl TrackStore for InMemoryTrackStore {
+    fn mtimes(&self) -> Result<HashMap<String, i64>> {
+        Ok(self.inner.lock().unwrap().clone())
+    }
+
+    fn upsert(&self, path: &str, mtime: i64) -> Result<()> {
+        self.inner.lock().unwrap().insert(path.to_owned(), mtime);
+        Ok(())
+    }
+
+    fn remove(&self, path: &str) -> Result<()> {
+        self.inner.lock().unwrap().remove(path);
+        Ok(())
+    }
+
+    fn count(&self) -> Result<u64> {
+        Ok(self.inner.lock().unwrap().len() as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obs(path: &str, mtime: i64) -> Observed {
+        Observed {
+            path: PathBuf::from(path),
+            mtime,
+        }
+    }
+
+    fn stored(pairs: &[(&str, i64)]) -> HashMap<String, i64> {
+        pairs.iter().map(|(p, m)| (p.to_string(), *m)).collect()
+    }
+
+    #[test]
+    fn diff_classifies_added_modified_removed_and_skips_unchanged() {
+        let prev = stored(&[("a", 1), ("b", 2), ("gone", 9)]);
+        let now = [obs("a", 1), obs("b", 5), obs("c", 3)];
+
+        let changes = diff(&prev, &now);
+
+        assert_eq!(changes.added, vec![PathBuf::from("c")]);
+        assert_eq!(changes.modified, vec![PathBuf::from("b")]);
+        assert_eq!(changes.removed, vec![PathBuf::from("gone")]);
+        // "a" is unchanged → in none of the buckets.
+        assert!(changes.upserted().eq([Path::new("c"), Path::new("b")]));
+    }
+
+    #[test]
+    fn diff_empty_when_nothing_changed() {
+        let prev = stored(&[("a", 1)]);
+        let now = [obs("a", 1)];
+        assert!(diff(&prev, &now).is_empty());
+    }
+
+    #[test]
+    fn in_memory_store_round_trips() {
+        let store = open_in_memory();
+        store.upsert("x", 10).unwrap();
+        store.upsert_many(&[("y".into(), 20), ("z".into(), 30)]).unwrap();
+        assert_eq!(store.count().unwrap(), 3);
+
+        let m = store.mtimes().unwrap();
+        assert_eq!(m.get("x"), Some(&10));
+        assert_eq!(m.get("y"), Some(&20));
+
+        store.remove("x").unwrap();
+        assert_eq!(store.count().unwrap(), 2);
+        assert!(!store.mtimes().unwrap().contains_key("x"));
+    }
+
+    #[test]
+    fn detect_changes_reads_store_then_diffs() {
+        let store = open_in_memory();
+        store.upsert("a", 1).unwrap();
+        let now = [obs("a", 1), obs("b", 2)];
+        let changes = detect_changes(&store, &now).unwrap();
+        assert_eq!(changes.added, vec![PathBuf::from("b")]);
+        assert!(changes.modified.is_empty());
+        assert!(changes.removed.is_empty());
+    }
+}

--- a/crates/sapphire-track/src/redb_store.rs
+++ b/crates/sapphire-track/src/redb_store.rs
@@ -1,0 +1,124 @@
+use std::{collections::HashMap, path::Path};
+
+use redb::{Database, ReadableTable, ReadableTableMetadata, TableDefinition};
+
+use crate::{Result, TrackStore};
+
+/// Single table mapping a file path to its last-seen mtime (epoch seconds).
+const TABLE: TableDefinition<&str, i64> = TableDefinition::new("tracked");
+
+/// Persistent [`TrackStore`] backed by a pure-Rust [redb] database.
+///
+/// The database is a rebuildable cache: callers version the filename (e.g.
+/// `track_v1.redb`) so that an incompatible redb format bump simply orphans
+/// the old file and a fresh one is created here.
+///
+/// [redb]: https://docs.rs/redb
+pub struct RedbTrackStore {
+    db: Database,
+}
+
+impl RedbTrackStore {
+    /// Open (or create) the database at `path`, ensuring the table exists so
+    /// that read transactions never fail on a brand-new file.
+    pub fn open(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let db = Database::create(path)?;
+        // Materialise the table once up front; `open_table` in a write txn
+        // creates it if missing.
+        let wtx = db.begin_write()?;
+        wtx.open_table(TABLE)?;
+        wtx.commit()?;
+        Ok(Self { db })
+    }
+}
+
+impl TrackStore for RedbTrackStore {
+    fn mtimes(&self) -> Result<HashMap<String, i64>> {
+        let rtx = self.db.begin_read()?;
+        let table = rtx.open_table(TABLE)?;
+        let mut out = HashMap::new();
+        for entry in table.iter()? {
+            let (k, v) = entry?;
+            out.insert(k.value().to_owned(), v.value());
+        }
+        Ok(out)
+    }
+
+    fn upsert(&self, path: &str, mtime: i64) -> Result<()> {
+        let wtx = self.db.begin_write()?;
+        {
+            let mut table = wtx.open_table(TABLE)?;
+            table.insert(path, mtime)?;
+        }
+        wtx.commit()?;
+        Ok(())
+    }
+
+    fn remove(&self, path: &str) -> Result<()> {
+        let wtx = self.db.begin_write()?;
+        {
+            let mut table = wtx.open_table(TABLE)?;
+            table.remove(path)?;
+        }
+        wtx.commit()?;
+        Ok(())
+    }
+
+    fn count(&self) -> Result<u64> {
+        let rtx = self.db.begin_read()?;
+        let table = rtx.open_table(TABLE)?;
+        Ok(table.len()?)
+    }
+
+    fn upsert_many(&self, entries: &[(String, i64)]) -> Result<()> {
+        let wtx = self.db.begin_write()?;
+        {
+            let mut table = wtx.open_table(TABLE)?;
+            for (path, mtime) in entries {
+                table.insert(path.as_str(), *mtime)?;
+            }
+        }
+        wtx.commit()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redb_round_trips_and_persists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("track_v1.redb");
+
+        {
+            let store = RedbTrackStore::open(&path).unwrap();
+            store.upsert("a", 1).unwrap();
+            store
+                .upsert_many(&[("b".into(), 2), ("c".into(), 3)])
+                .unwrap();
+            assert_eq!(store.count().unwrap(), 3);
+            store.remove("a").unwrap();
+            assert_eq!(store.count().unwrap(), 2);
+        }
+
+        // Reopen: data survives across instances.
+        let store = RedbTrackStore::open(&path).unwrap();
+        let m = store.mtimes().unwrap();
+        assert_eq!(m.len(), 2);
+        assert_eq!(m.get("b"), Some(&2));
+        assert!(!m.contains_key("a"));
+    }
+
+    #[test]
+    fn fresh_db_reads_empty_without_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = RedbTrackStore::open(&tmp.path().join("track_v1.redb")).unwrap();
+        assert_eq!(store.count().unwrap(), 0);
+        assert!(store.mtimes().unwrap().is_empty());
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,6 +56,9 @@ pub enum Error {
     Sync(#[from] sapphire_sync::Error),
 
     #[error(transparent)]
+    Track(#[from] sapphire_track::Error),
+
+    #[error(transparent)]
     Walkdir(#[from] walkdir::Error),
 }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -5,20 +5,17 @@ use std::{
 };
 
 use sapphire_retrieve::{Chunker, Document, JsonlChunker, RetrieveStore, TomlChunker};
+use sapphire_track::TrackStore;
 use thiserror::Error;
 
 use crate::{error::Result, workspace::Workspace};
 
 /// Return the mtime of `path` as seconds since UNIX epoch, or 0 on error.
+///
+/// Thin re-export of [`sapphire_track::mtime_secs`] kept under the indexer's
+/// name for the single-file update paths in `workspace_state`.
 pub(crate) fn file_mtime_secs(path: &Path) -> i64 {
-    path.metadata()
-        .and_then(|m| m.modified())
-        .map(|t| {
-            t.duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs() as i64
-        })
-        .unwrap_or(0)
+    sapphire_track::mtime_secs(path)
 }
 
 const MARKDOWN_EXTENSIONS: &[&str] = &["md", "markdown", "txt", "rst", "org"];
@@ -121,13 +118,15 @@ pub(crate) fn build_document_from_disk(path: &Path, doc_id: i64) -> std::io::Res
 pub fn sync_workspace(
     workspace: &Workspace,
     retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
+    track: &dyn TrackStore,
 ) -> Result<(usize, usize)> {
     let mut hook = NoopHook;
-    let report =
-        sync_workspace_full_with_hook(workspace, retrieve_db, &mut hook).map_err(|e| match e {
+    let report = sync_workspace_full_with_hook(workspace, retrieve_db, track, &mut hook).map_err(
+        |e| match e {
             SyncWithHookError::Workspace(e) => e,
             SyncWithHookError::Hook(never) => match never {},
-        })?;
+        },
+    )?;
     Ok((report.upserted, report.removed))
 }
 
@@ -239,9 +238,10 @@ fn collect_candidates(root: &Path) -> Result<Vec<PathBuf>> {
 pub fn sync_workspace_with_hook<H: IndexHook>(
     workspace: &Workspace,
     retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
+    track: &dyn TrackStore,
     hook: &mut H,
 ) -> std::result::Result<SyncReport, SyncWithHookError<H::Error>> {
-    sync_inner(workspace, retrieve_db, hook, /* full = */ false)
+    sync_inner(workspace, retrieve_db, track, hook, /* full = */ false)
 }
 
 /// Hook-driven **full** sync.
@@ -252,18 +252,20 @@ pub fn sync_workspace_with_hook<H: IndexHook>(
 pub fn sync_workspace_full_with_hook<H: IndexHook>(
     workspace: &Workspace,
     retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
+    track: &dyn TrackStore,
     hook: &mut H,
 ) -> std::result::Result<SyncReport, SyncWithHookError<H::Error>> {
-    sync_inner(workspace, retrieve_db, hook, /* full = */ true)
+    sync_inner(workspace, retrieve_db, track, hook, /* full = */ true)
 }
 
 fn sync_inner<H: IndexHook>(
     workspace: &Workspace,
     retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
+    track: &dyn TrackStore,
     hook: &mut H,
     full: bool,
 ) -> std::result::Result<SyncReport, SyncWithHookError<H::Error>> {
-    let known_mtimes = retrieve_db.file_mtimes().map_err(crate::Error::from)?;
+    let known_mtimes = track.mtimes().map_err(crate::Error::from)?;
     let existing_ids: HashSet<i64> = retrieve_db
         .document_ids()
         .map_err(crate::Error::from)?
@@ -298,11 +300,16 @@ fn sync_inner<H: IndexHook>(
             continue;
         };
 
-        retrieve_db
-            .upsert_file(&path_str, disk_mtime)
-            .map_err(crate::Error::from)?;
+        // Index into the retrieve DB first, then record the mtime. If we crash
+        // between the two, the file is re-detected as changed next run and
+        // re-indexed (idempotent via the stable `doc_id`) — never silently
+        // skipped, which the reverse order would risk. See the crate-split
+        // atomicity note in the design.
         retrieve_db
             .upsert_document(&doc)
+            .map_err(crate::Error::from)?;
+        track
+            .upsert(&path_str, disk_mtime)
             .map_err(crate::Error::from)?;
         upserted += 1;
     }
@@ -316,9 +323,6 @@ fn sync_inner<H: IndexHook>(
             continue;
         }
         hook.on_removed(path_str).map_err(SyncWithHookError::Hook)?;
-        retrieve_db
-            .remove_file(path_str)
-            .map_err(crate::Error::from)?;
         let doc_id = path_to_doc_id(Path::new(path_str));
         if existing_ids.contains(&doc_id) && removed_doc_ids.insert(doc_id) {
             retrieve_db
@@ -326,6 +330,7 @@ fn sync_inner<H: IndexHook>(
                 .map_err(crate::Error::from)?;
             removed += 1;
         }
+        track.remove(path_str).map_err(crate::Error::from)?;
     }
 
     // Orphan documents: IDs in the DB with no corresponding file row.
@@ -378,8 +383,8 @@ pub(crate) fn unwrap_infallible(err: SyncWithHookError<std::convert::Infallible>
     }
 }
 
-/// Walk the workspace and update only files whose mtime has changed since the
-/// last sync. Also removes documents (and their file rows) for files that no
+/// Walk the workspace and update only files whose mtime (tracked in `track`)
+/// has changed since the last sync. Also removes documents for files that no
 /// longer exist.
 ///
 /// Returns `(upserted, removed)`.
@@ -388,10 +393,11 @@ pub(crate) fn unwrap_infallible(err: SyncWithHookError<std::convert::Infallible>
 pub fn sync_workspace_incremental(
     workspace: &Workspace,
     retrieve_db: Arc<dyn RetrieveStore + Send + Sync>,
+    track: &dyn TrackStore,
 ) -> Result<(usize, usize)> {
     let mut hook = NoopHook;
-    let report =
-        sync_workspace_with_hook(workspace, retrieve_db, &mut hook).map_err(unwrap_infallible)?;
+    let report = sync_workspace_with_hook(workspace, retrieve_db, track, &mut hook)
+        .map_err(unwrap_infallible)?;
     Ok((report.upserted, report.removed))
 }
 
@@ -412,7 +418,12 @@ mod tests {
         CTX.get_or_init(|| AppContext::new("indexer-hook-test"))
     }
 
-    fn make_workspace() -> (TempDir, Workspace, Arc<dyn RetrieveStore + Send + Sync>) {
+    fn make_workspace() -> (
+        TempDir,
+        Workspace,
+        Arc<dyn RetrieveStore + Send + Sync>,
+        sapphire_track::InMemoryTrackStore,
+    ) {
         // Use a non-dotted prefix: hook-aware sync skips dotted directories at
         // any depth (matching `sync_workspace_incremental`), which includes the
         // workspace root.
@@ -422,7 +433,8 @@ mod tests {
         let workspace = Workspace::from_root(ctx(), &root).unwrap();
         let db_path = root.join(".indexer-hook-test").join("retrieve.sqlite");
         let db = open_sqlite_fts(&db_path);
-        (tmp, workspace, db)
+        let track = sapphire_track::open_in_memory();
+        (tmp, workspace, db, track)
     }
 
     struct RecordingHook {
@@ -466,12 +478,12 @@ mod tests {
 
     #[test]
     fn hook_sees_changed_and_workspace_indexes_default() {
-        let (tmp, ws, db) = make_workspace();
+        let (tmp, ws, db, track) = make_workspace();
         let file = tmp.path().join("note.md");
         fs::write(&file, "hello world").unwrap();
 
         let mut hook = RecordingHook::new();
-        let report = sync_workspace_with_hook(&ws, db.clone(), &mut hook).unwrap();
+        let report = sync_workspace_with_hook(&ws, db.clone(), &track, &mut hook).unwrap();
 
         assert_eq!(report.upserted, 1);
         assert_eq!(report.removed, 0);
@@ -480,22 +492,22 @@ mod tests {
         assert_eq!(hook.after_sweep_count.get(), 1);
 
         assert_eq!(db.document_count().unwrap(), 1);
-        let mtimes = db.file_mtimes().unwrap();
+        let mtimes = track.mtimes().unwrap();
         assert!(mtimes.contains_key(file.to_string_lossy().as_ref()));
     }
 
     #[test]
     fn unchanged_file_skips_hook_on_second_run() {
-        let (tmp, ws, db) = make_workspace();
+        let (tmp, ws, db, track) = make_workspace();
         let file = tmp.path().join("stable.md");
         fs::write(&file, "stable").unwrap();
 
         let mut hook = RecordingHook::new();
-        let first = sync_workspace_with_hook(&ws, db.clone(), &mut hook).unwrap();
+        let first = sync_workspace_with_hook(&ws, db.clone(), &track, &mut hook).unwrap();
         assert_eq!(first.upserted, 1);
 
         let mut hook2 = RecordingHook::new();
-        let second = sync_workspace_with_hook(&ws, db.clone(), &mut hook2).unwrap();
+        let second = sync_workspace_with_hook(&ws, db.clone(), &track, &mut hook2).unwrap();
         assert_eq!(second.upserted, 0);
         assert!(hook2.changed.is_empty());
         assert_eq!(hook2.after_sweep_count.get(), 1);
@@ -503,55 +515,55 @@ mod tests {
 
     #[test]
     fn full_sync_with_hook_visits_every_file_regardless_of_mtime() {
-        let (tmp, ws, db) = make_workspace();
+        let (tmp, ws, db, track) = make_workspace();
         let file = tmp.path().join("stable.md");
         fs::write(&file, "stable").unwrap();
 
         let mut h1 = RecordingHook::new();
-        sync_workspace_with_hook(&ws, db.clone(), &mut h1).unwrap();
+        sync_workspace_with_hook(&ws, db.clone(), &track, &mut h1).unwrap();
         assert_eq!(h1.changed.len(), 1);
 
         // Second incremental call: mtime unchanged → hook skipped.
         let mut h2 = RecordingHook::new();
-        sync_workspace_with_hook(&ws, db.clone(), &mut h2).unwrap();
+        sync_workspace_with_hook(&ws, db.clone(), &track, &mut h2).unwrap();
         assert_eq!(h2.changed.len(), 0);
 
         // Second full call: mtime unchanged but hook is still invoked.
         let mut h3 = RecordingHook::new();
-        let r = sync_workspace_full_with_hook(&ws, db, &mut h3).unwrap();
+        let r = sync_workspace_full_with_hook(&ws, db, &track, &mut h3).unwrap();
         assert_eq!(h3.changed.len(), 1);
         assert_eq!(r.upserted, 1);
     }
 
     #[test]
     fn removed_file_triggers_on_removed_before_db_delete() {
-        let (tmp, ws, db) = make_workspace();
+        let (tmp, ws, db, track) = make_workspace();
         let file = tmp.path().join("doomed.md");
         fs::write(&file, "bye").unwrap();
 
         let mut hook = RecordingHook::new();
-        sync_workspace_with_hook(&ws, db.clone(), &mut hook).unwrap();
+        sync_workspace_with_hook(&ws, db.clone(), &track, &mut hook).unwrap();
         let file_str = file.to_string_lossy().into_owned();
-        assert!(db.file_mtimes().unwrap().contains_key(&file_str));
+        assert!(track.mtimes().unwrap().contains_key(&file_str));
 
         fs::remove_file(&file).unwrap();
         let mut hook2 = RecordingHook::new();
-        let report = sync_workspace_with_hook(&ws, db.clone(), &mut hook2).unwrap();
+        let report = sync_workspace_with_hook(&ws, db.clone(), &track, &mut hook2).unwrap();
 
         assert_eq!(report.removed, 1);
         assert_eq!(hook2.removed, vec![file_str.clone()]);
-        assert!(!db.file_mtimes().unwrap().contains_key(&file_str));
+        assert!(!track.mtimes().unwrap().contains_key(&file_str));
         assert_eq!(db.document_count().unwrap(), 0);
     }
 
     #[test]
     fn after_sweep_runs_exactly_once_per_call() {
-        let (tmp, ws, db) = make_workspace();
+        let (tmp, ws, db, track) = make_workspace();
         fs::write(tmp.path().join("a.md"), "a").unwrap();
         fs::write(tmp.path().join("b.md"), "b").unwrap();
 
         let mut hook = RecordingHook::new();
-        sync_workspace_with_hook(&ws, db, &mut hook).unwrap();
+        sync_workspace_with_hook(&ws, db, &track, &mut hook).unwrap();
         assert_eq!(hook.after_sweep_count.get(), 1);
         assert_eq!(hook.changed.len(), 2);
     }
@@ -577,24 +589,24 @@ mod tests {
 
     #[test]
     fn hook_error_is_propagated_as_hook_variant() {
-        let (tmp, ws, db) = make_workspace();
+        let (tmp, ws, db, track) = make_workspace();
         fs::write(tmp.path().join("a.md"), "a").unwrap();
         let mut hook = ErrorOnFirstChange;
-        let err = sync_workspace_with_hook(&ws, db, &mut hook).unwrap_err();
+        let err = sync_workspace_with_hook(&ws, db, &track, &mut hook).unwrap_err();
         assert!(matches!(err, SyncWithHookError::Hook(Boom)));
     }
 
     #[test]
     fn wrapper_preserves_legacy_signature_and_counts() {
-        let (tmp, ws, db) = make_workspace();
+        let (tmp, ws, db, track) = make_workspace();
         fs::write(tmp.path().join("a.md"), "a").unwrap();
         fs::write(tmp.path().join("b.md"), "b").unwrap();
 
-        let (up, rm) = sync_workspace_incremental(&ws, db.clone()).unwrap();
+        let (up, rm) = sync_workspace_incremental(&ws, db.clone(), &track).unwrap();
         assert_eq!((up, rm), (2, 0));
 
         fs::remove_file(tmp.path().join("a.md")).unwrap();
-        let (up2, rm2) = sync_workspace_incremental(&ws, db).unwrap();
+        let (up2, rm2) = sync_workspace_incremental(&ws, db, &track).unwrap();
         assert_eq!((up2, rm2), (0, 1));
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -209,6 +209,14 @@ impl Workspace {
         #[cfg(not(feature = "sqlite-store"))]
         self.cache_dir().join("retrieve.db")
     }
+
+    /// Path to the [`sapphire-track`](sapphire_track) mtime database file.
+    ///
+    /// The filename is versioned so an incompatible redb format bump simply
+    /// orphans the old file; the store is a rebuildable cache.
+    pub fn track_db_path(&self) -> PathBuf {
+        self.cache_dir().join("track_v1.redb")
+    }
 }
 
 fn resolve_cwd() -> Result<PathBuf> {

--- a/src/workspace_state.rs
+++ b/src/workspace_state.rs
@@ -11,6 +11,7 @@ use sapphire_retrieve::{
 };
 #[cfg(feature = "sqlite-store")]
 use sapphire_retrieve::{open_sqlite_fts, open_sqlite_vec};
+use sapphire_track::TrackStore;
 use tokio::sync::OnceCell;
 
 use crate::{
@@ -56,6 +57,9 @@ pub struct RetrieveParams<'a> {
 pub struct WorkspaceState {
     pub workspace: Workspace,
     retrieve_db: Mutex<Arc<dyn RetrieveStore + Send + Sync>>,
+    /// mtime-based change-detection store (see [`sapphire_track`]). Unlike the
+    /// retrieve backend it is never swapped at runtime, so it needs no lock.
+    track_db: Arc<dyn TrackStore + Send + Sync>,
     embedder: OnceCell<Option<Box<dyn Embedder + Send + Sync>>>,
     sync_backend: Option<Box<dyn sapphire_sync::SyncBackend + Send + Sync>>,
 }
@@ -138,8 +142,10 @@ impl WorkspaceState {
     /// git repository.  Silently falls back to no backend if git is not found.
     pub fn open(workspace: Workspace) -> Result<Self> {
         let backend = Self::open_initial_backend(&workspace);
+        let track_db = Self::open_initial_track(&workspace)?;
         let mut state = Self {
             retrieve_db: Mutex::new(backend),
+            track_db,
             workspace,
             embedder: OnceCell::new(),
             sync_backend: None,
@@ -160,9 +166,14 @@ impl WorkspaceState {
             use sapphire_retrieve::lancedb_store;
             let _ = std::fs::remove_dir_all(lancedb_store::data_dir(&workspace.cache_dir()));
         }
+        // Drop the mtime snapshot too, so the rebuilt retrieve index and the
+        // track store start from a consistent (empty) state.
+        let _ = std::fs::remove_file(workspace.track_db_path());
         let backend = Self::open_initial_backend(&workspace);
+        let track_db = Self::open_initial_track(&workspace)?;
         Ok(Self {
             retrieve_db: Mutex::new(backend),
+            track_db,
             workspace,
             embedder: OnceCell::new(),
             sync_backend: None,
@@ -324,6 +335,11 @@ impl WorkspaceState {
         Arc::clone(&*self.retrieve_db.lock().unwrap())
     }
 
+    /// Borrow the mtime change-detection store.
+    pub fn track_db(&self) -> &(dyn TrackStore + Send + Sync) {
+        self.track_db.as_ref()
+    }
+
     pub fn embedder(&self) -> Option<&dyn Embedder> {
         Some(self.embedder.get()?.as_ref()?.as_ref())
     }
@@ -350,15 +366,7 @@ impl WorkspaceState {
         let abs = resolved.as_path();
         let path_str = abs.to_string_lossy().into_owned();
 
-        let mtime = abs
-            .metadata()
-            .and_then(|m| m.modified())
-            .map(|t| {
-                t.duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs() as i64
-            })
-            .unwrap_or(0);
+        let mtime = file_mtime_secs(abs);
 
         let body = std::fs::read_to_string(abs)?;
         let doc_id = path_to_doc_id(abs);
@@ -404,10 +412,12 @@ impl WorkspaceState {
             }
         };
 
+        // Index first, then record the mtime (see the atomicity note in
+        // `indexer::sync_inner`).
         let db = self.retrieve_db();
-        db.upsert_file(&path_str, mtime)?;
         db.upsert_document(&doc)?;
         db.rebuild_fts()?;
+        self.track_db().upsert(&path_str, mtime)?;
 
         if let Some(sync) = &self.sync_backend {
             sync.add_file(abs)?;
@@ -433,8 +443,8 @@ impl WorkspaceState {
 
         let db = self.retrieve_db();
         db.remove_document(doc_id)?;
-        db.remove_file(&path_str)?;
         db.rebuild_fts()?;
+        self.track_db().remove(&path_str)?;
 
         if let Some(sync) = &self.sync_backend {
             sync.remove_file(abs)?;
@@ -480,9 +490,11 @@ impl WorkspaceState {
             .map_err(|e| SyncWithHookError::Workspace(Error::from(e)))?;
 
         let db = self.retrieve_db();
-        db.upsert_file(&path_str, mtime).map_err(map_retrieve_err)?;
         db.upsert_document(&doc).map_err(map_retrieve_err)?;
         db.rebuild_fts().map_err(map_retrieve_err)?;
+        self.track_db()
+            .upsert(&path_str, mtime)
+            .map_err(|e| SyncWithHookError::Workspace(Error::from(e)))?;
 
         if let Some(sync) = &self.sync_backend {
             sync.add_file(abs)
@@ -515,8 +527,10 @@ impl WorkspaceState {
 
         let db = self.retrieve_db();
         db.remove_document(doc_id).map_err(map_retrieve_err)?;
-        db.remove_file(&path_str).map_err(map_retrieve_err)?;
         db.rebuild_fts().map_err(map_retrieve_err)?;
+        self.track_db()
+            .remove(&path_str)
+            .map_err(|e| SyncWithHookError::Workspace(Error::from(e)))?;
 
         if let Some(sync) = &self.sync_backend {
             sync.remove_file(abs)
@@ -736,7 +750,7 @@ impl WorkspaceState {
 
     /// Scan the workspace and incrementally sync all files into the retrieve DB.
     pub fn sync(&self) -> Result<(usize, usize)> {
-        sync_workspace(&self.workspace, self.retrieve_db())
+        sync_workspace(&self.workspace, self.retrieve_db(), self.track_db())
     }
 
     /// Run a mtime-based incremental retrieve cache refresh.
@@ -746,7 +760,7 @@ impl WorkspaceState {
     ///
     /// Returns `(upserted, removed)`.
     pub fn sync_retrieve(&self) -> Result<(usize, usize)> {
-        sync_workspace_incremental(&self.workspace, self.retrieve_db())
+        sync_workspace_incremental(&self.workspace, self.retrieve_db(), self.track_db())
     }
 
     /// Hook-aware full sync (counterpart of [`sync`](Self::sync)).
@@ -758,7 +772,7 @@ impl WorkspaceState {
         &self,
         hook: &mut H,
     ) -> std::result::Result<SyncReport, SyncWithHookError<H::Error>> {
-        sync_workspace_full_with_hook(&self.workspace, self.retrieve_db(), hook)
+        sync_workspace_full_with_hook(&self.workspace, self.retrieve_db(), self.track_db(), hook)
     }
 
     /// Hook-aware incremental sync (counterpart of
@@ -770,7 +784,7 @@ impl WorkspaceState {
         &self,
         hook: &mut H,
     ) -> std::result::Result<SyncReport, SyncWithHookError<H::Error>> {
-        sync_workspace_with_hook(&self.workspace, self.retrieve_db(), hook)
+        sync_workspace_with_hook(&self.workspace, self.retrieve_db(), self.track_db(), hook)
     }
 
     /// Run a full git sync cycle (commit → pull → push), if a sync backend is
@@ -798,7 +812,8 @@ impl WorkspaceState {
     ///
     /// Returns `(upserted, removed, embedded)`.
     pub async fn sync_and_embed(&self, retrieve: &RetrieveConfig) -> Result<(usize, usize, usize)> {
-        let (upserted, removed) = sync_workspace(&self.workspace, self.retrieve_db())?;
+        let (upserted, removed) =
+            sync_workspace(&self.workspace, self.retrieve_db(), self.track_db())?;
 
         let Some(embed_cfg) = retrieve.embedding.as_ref() else {
             return Ok((upserted, removed, 0));
@@ -932,6 +947,30 @@ impl WorkspaceState {
         {
             let _ = workspace;
             sapphire_retrieve::open_in_memory()
+        }
+    }
+
+    /// Create the mtime change-detection store appropriate for the compiled
+    /// features.
+    ///
+    /// Mirrors [`open_initial_backend`](Self::open_initial_backend): a
+    /// persistent redb store when a persistent retrieve backend is in use
+    /// (`sqlite-store`), otherwise an ephemeral in-memory store so the two
+    /// never drift (a persistent mtime snapshot paired with an empty in-memory
+    /// index would make changed files look unchanged).
+    fn open_initial_track(
+        workspace: &Workspace,
+    ) -> Result<Arc<dyn TrackStore + Send + Sync>> {
+        #[cfg(feature = "sqlite-store")]
+        {
+            Ok(Arc::new(sapphire_track::open_redb(
+                &workspace.track_db_path(),
+            )?))
+        }
+        #[cfg(not(feature = "sqlite-store"))]
+        {
+            let _ = workspace;
+            Ok(Arc::new(sapphire_track::open_in_memory()))
         }
     }
 


### PR DESCRIPTION
## 背景

ファイル変更検知（path→mtime の追跡）が `sapphire-retrieve` に同居していた（`RetrieveStore` の `file_mtimes`/`upsert_file`/`remove_file`/`file_count` と各バックエンドの `files` テーブル）。

これは概念上の責務違反で、「アプリが更新をフックしたいファイル」と「retrieve 可能なファイル」がたまたま一致していたから機能していただけ。retrieve 対象外のファイル（例: オーディオファイル）の更新をフックしたくなった場合、mtime 追跡が retrieve にあるせいで retrieve の監視スコープに非対象ファイルを押し込む羽目になる。

## 変更

ファイル変更検知をファイル種別非依存の新クレート **`sapphire-track`** に切り出した。

### `sapphire-track`（新規・純 Rust）
- `TrackStore` トレイト（`mtimes`/`upsert`/`remove`/`count`/`upsert_many`）+ **redb** バックエンド（純 Rust・C 依存なし → sqlite-sys 競合回避）と in-memory バックエンド
- 純粋関数 `diff`/`detect_changes`、`scan`/`mtime_secs`、`Changes`/`Observed`
- どのパスを追跡するかは呼び出し側のポリシー。store は再構築可能なキャッシュ扱いで、`track_v1.redb` とファイル名でバージョニング

### `sapphire-retrieve`（retrieve 専念に）
- `RetrieveStore` から file-tracking 4メソッドを除去
- SQLite `SCHEMA_VERSION` 4→5（`files` テーブル削除、旧 DB は自動 wipe→再構築）、LanceDB / in-memory も対応

### `sapphire-workspace`（協調層）
- `Workspace::track_db_path()` / `Error::Track` 追加
- indexer の各 sync 関数に `&dyn TrackStore` を追加し mtime 操作を track ストアへ
- **順序を「retrieve に index → track に mtime 記録」に変更**。中断時は「冗長な再インデックス（冪等）」で済み、「永久スキップ」を回避
- `WorkspaceState` に `track_db` フィールド/`track_db()`/`open_initial_track()` 追加（`sqlite-store` on→redb 永続、off→in-memory で retrieve と整合）。`rebuild()` で track DB も wipe
- `IndexHook` サイドチャネル API は維持（mtime 追跡と直交）

## 検証
- `cargo build --workspace`（全デフォルト機能, lancedb 含む）✓
- `cargo test --workspace` 全パス（track 6 / workspace 15 / retrieve doctest 等）✓
- `cargo clippy --workspace --all-targets` exit 0（`result_large_err` 警告のみ、lancedb::Error 起因の既存警告でスコープ外）
- `--no-default-features --features sqlite-store` / `--no-default-features`（in-memory）両構成ともコンパイル・テスト ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)